### PR TITLE
Add support for Centos-8

### DIFF
--- a/vars/CentOS-8.yml
+++ b/vars/CentOS-8.yml
@@ -1,0 +1,12 @@
+---:
+__cockpit_repo: CentOS-{{ansible_distribution_major_version}} - AppStream
+__cockpit_daemon: cockpit
+__cockpit_packages:
+  - cockpit
+  - cockpit-bridge
+  - cockpit-networkmanager
+  - cockpit-packagekit
+  - cockpit-selinux
+  - cockpit-storaged
+  - cockpit-system
+  - cockpit-ws


### PR DESCRIPTION
Running on CentOS-8 fails with ` "message": "Could not find or access 'CentOS-8.yml`

Added  `vars/CentOS-8.yml`  based off the existing RedHat one.