### PR TITLE
Fix minimal vs. default packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,16 @@ Example of using the predefined package sets.  This is the recommended method fo
 ```yaml
 cockpit_packages: default
     # equivalent to
+    #  - cockpit
     #  - cockpit-networkmanager
     #  - cockpit-packagekit
     #  - cockpit-selinux
     #  - cockpit-storaged
-    #  - cockpit-system
 
 cockpit_packages: minimal
     # equivalent to
-    #  - cockpit
+    #  - cockpit-system
+    #  - cockpit-ws
 
 cockpit_packages: full
     # equivalent to globbing all of them

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -6,14 +6,14 @@
 #
 #
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 __cockpit_packages_default:
   - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-  - cockpit-system
 __cockpit_packages_full:
   - cockpit-composer
   - cockpit-dashboard

--- a/vars/CentOS-8.yml
+++ b/vars/CentOS-8.yml
@@ -6,13 +6,14 @@
 #
 #
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 __cockpit_packages_default:
+  - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-  - cockpit-system
 __cockpit_packages_full:
   - cockpit-*
 __cockpit_packages:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,13 +1,12 @@
 ---
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 __cockpit_packages_default:
-  - cockpit-bridge
+  - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-storaged
-  - cockpit-system
-  - cockpit-ws
 __cockpit_packages_full:
   - cockpit-dashboard
   - cockpit-doc

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,12 +1,13 @@
 ---
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 __cockpit_packages_default:
+  - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-  - cockpit-system
 __cockpit_packages_full:
   - cockpit-*
 __cockpit_packages:

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -10,14 +10,14 @@
 #
 #
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 __cockpit_packages_default:
   - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-  - cockpit-system
 __cockpit_packages_full:
   - cockpit-composer
   - cockpit-dashboard

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -9,13 +9,14 @@
 # done;
 #
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 __cockpit_packages_default:
+  - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-  - cockpit-system
 __cockpit_packages_full:
   - cockpit-*
 __cockpit_packages:

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -2,14 +2,15 @@
 __cockpit_daemon: cockpit.socket
 
 __cockpit_packages_minimal:
-  - cockpit
+  - cockpit-system
+  - cockpit-ws
 
 __cockpit_packages_default:
+  - cockpit
   - cockpit-networkmanager
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-  - cockpit-system
 
 __cockpit_packages_full:
   - cockpit-*


### PR DESCRIPTION
The absolute minimum to give you a working Cockpit is
cockpit-{system,ws}. All distros provide an empty "cockpit" meta-package
that pulls in these, plus recommends a bunch of standard packages like
cockpit-packagekit. But don't rely on recommends to keep the role
robust.
