### PR TITLE
Fix centos6 repos; use standard centos images; add centos8

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@1.0.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@1.0.1"
   LSR_ANSIBLES: 'ansible==2.7.* ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,8 +7,7 @@ galaxy_info:
   platforms:
     - name: Fedora
       versions:
-        - 29
-        - 30
+        - all
     - name: EL
       versions:
         - 7

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -7,9 +7,22 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+RUN set -euo pipefail; \
+    pkgs="python sudo yum-plugin-ovl bash"; \
+    if grep 'CentOS release 6' /etc/centos-release > /dev/null 2>&1; then \
+      for file in /etc/yum.repos.d/CentOS-*.repo; do \
+        if ! grep '^baseurl=.*vault[.]centos[.]org' "$file"; then \
+          sed -i -e 's,^mirrorlist,#mirrorlist,' \
+              -e 's,^#baseurl=,baseurl=,' \
+              -e 's,mirror.centos.org/centos/$releasever,vault.centos.org/6.10,' \
+              "$file"; \
+        fi; \
+      done; \
+      pkgs="$pkgs upstart chkconfig initscripts"; \
+    fi; \
+    if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-devel python3-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y $pkgs && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,27 +5,33 @@ dependency:
 driver:
   name: docker
 lint:
-  name: yamllint
   enabled: false
-  options:
-    config-file: .yamllint.yml
 platforms:
-  - name: centos-6
-    image: docker.io/linuxsystemroles/centos-6
-    privileged: true
   - name: centos-7
-    image: docker.io/linuxsystemroles/centos-7
+    image: registry.centos.org/centos/systemd:latest
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
+    command: /usr/lib/systemd/systemd --system
+  - name: centos-8
+    image: registry.centos.org/centos:8
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    command: /usr/lib/systemd/systemd --system
+    groups:
+      - py3
 provisioner:
   name: ansible
   log: true
   lint:
     enabled: false
-    name: ansible-lint
   playbooks:
     converge: ../../tests/tests_default.yml
+  inventory:
+    group_vars:
+      py3:
+        ansible_python_interpreter: /usr/bin/python3
 scenario:
   name: default
   test_sequence:
@@ -35,8 +41,3 @@ scenario:
     - idempotence
     - check
     - destroy
-verifier:
-  name: testinfra
-  lint:
-    name: flake8
-    enabled: false


### PR DESCRIPTION
Use the new vault.centos.org repos.  Fix the yum repo configs in the
image if necessary to use these new repos.
Use the standard centos images from the centos registry rather than
custom lsr images from dockerhub.
Add support for centos8.  Note that using ansible 2.7 on centos8 requires
setting /usr/bin/python3 to be the ansible python interpreter.  Later
versions of ansible have better auto-detection.  We can get rid of this
once we drop support for ansible 2.7
Use tox-lsr 1.0.1