### PR TITLE
Variables to control if Cockpit is enabled/running

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cockpit_packages: full
 ```
 
     cockpit_enabled: yes
-Boolean variable to control if Cockpit is enabled to start automatically at boot (default yes).
+Boolean variable to control if Cockpit is enabled to start automatically on boot (default yes).
 
     cockpit_started: yes
 Boolean variable to control if Cockpit should be started/running (default yes). 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ cockpit_packages: full
         #  - cockpit-tests
 ```
 
+    cockpit_enabled: yes
+Boolean falg to control if Cockpit is enabled to start automatically at boot (default yes).
+
+    cockpit_started: yes
+Boolean falg to control if Cockpit should be started/running (default yes). 
+
 ## Example Playbooks
 The most simple example.
 ```yaml

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ cockpit_packages: full
 ```
 
     cockpit_enabled: yes
-Boolean falg to control if Cockpit is enabled to start automatically at boot (default yes).
+Boolean variable to control if Cockpit is enabled to start automatically at boot (default yes).
 
     cockpit_started: yes
-Boolean falg to control if Cockpit should be started/running (default yes). 
+Boolean variable to control if Cockpit should be started/running (default yes). 
 
 ## Example Playbooks
 The most simple example.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 # public vars if user defined, else defaults from internal vars
 cockpit_packages: default
+cockpit_enabled: yes
+cockpit_started: yes
 
 # internal vars
 __cockpit_daemon: cockpit.socket

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,8 @@
     - "setup-{{ ansible_pkg_mgr }}.yml"
     - "setup-default.yml"
 
-- name: Ensure Cockpit Web Console is started/stopped based on cockpit_started variable
-  service:
-    name: "{{ __cockpit_daemon }}"
-    state: "{{ 'started' if cockpit_started | bool else 'stopped' }}"
-
-- name: Ensure Cockpit Web Console is enabled/disabled on boot based on cockpit_enabled variable
+- name: Ensure Cockpit Web Console is started/stopped and enabled/disabled
   service:
     name: "{{ __cockpit_daemon }}"
     enabled: "{{ cockpit_enabled | bool }}"
+    state: "{{ 'started' if cockpit_started | bool else 'stopped' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,8 +13,12 @@
     - "setup-{{ ansible_pkg_mgr }}.yml"
     - "setup-default.yml"
 
-- name: Ensure Cockpit Web Console is started and enabled on boot.
+- name: Ensure Cockpit Web Console is started/stopped based on cockpit_started.
   service:
     name: "{{ __cockpit_daemon }}"
-    state: started
-    enabled: yes
+    state: "{{ 'started' if cockpit_started | bool else 'stopped' }}"
+
+- name: Ensure Cockpit Web Console is enabled/disabled on boot based on cockpit_enabled var.
+  service:
+    name: "{{ __cockpit_daemon }}"
+    enabled: "{{ cockpit_enabled | bool }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,12 @@
     - "setup-{{ ansible_pkg_mgr }}.yml"
     - "setup-default.yml"
 
-- name: Ensure Cockpit Web Console is started/stopped based on cockpit_started.
+- name: Ensure Cockpit Web Console is started/stopped based on cockpit_started variable
   service:
     name: "{{ __cockpit_daemon }}"
     state: "{{ 'started' if cockpit_started | bool else 'stopped' }}"
 
-- name: Ensure Cockpit Web Console is enabled/disabled on boot based on cockpit_enabled var.
+- name: Ensure Cockpit Web Console is enabled/disabled on boot based on cockpit_enabled variable
   service:
     name: "{{ __cockpit_daemon }}"
     enabled: "{{ cockpit_enabled | bool }}"


### PR DESCRIPTION
In some situations, you might want to install Cockpit but not start/enable it (i.e. if using the Satellite and Cockpit integration, it works without Cockpit being started/enabled).  