### PR TITLE
Drop cockpit-dashboard from Debian's "full" list

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,7 +7,6 @@ __cockpit_packages_default:
   - cockpit-packagekit
   - cockpit-storaged
 __cockpit_packages_full:
-  - cockpit-dashboard
   - cockpit-doc
   - cockpit-machines
   - cockpit-pcp
@@ -18,7 +17,6 @@ __cockpit_packages:
 # --------------------
 #  - cockpit-389-ds
 #  - cockpit-composer
-#  - cockpit-dashboard
 #  - cockpit-doc
 #  - cockpit-docker
 #  - cockpit-kdump


### PR DESCRIPTION
Current Debian 11 stable has Cockpit 239, which also does not build
cockpit-dashboard any more.