### PR TITLE
tests: Assert some assumptions about the default role behaviour

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,3 +2,37 @@
 - hosts: all
   roles:
     - linux-system-roles.cockpit
+
+  tasks:
+    - name: test - socket is active  # noqa 303 command-instead-of-module
+      command: systemctl is-active cockpit.socket
+      changed_when: false
+
+    - name: test - socket is enabled  # noqa 303 command-instead-of-module
+      command: systemctl is-enabled cockpit.socket
+      changed_when: false
+
+    - name: test - cockpit works with TLS
+      get_url:
+        dest: /run/out
+        url: https://localhost:9090
+        validate_certs: no
+
+    - name: test - no configuration file
+      stat:
+        path: /etc/cockpit/cockpit.conf
+      register: result
+      failed_when: result.stat.exists
+
+    # cleanup
+
+    - name: test - cleanup
+      package:
+        name:
+          # everything else depends on one of these two, so will be removed along
+          - cockpit-bridge
+          - cockpit-ws
+        state: absent
+      tags:
+        - always
+        - tests::cleanup


### PR DESCRIPTION
Check the socket state, that cockpit's web server works, and that the
role does not create a config file.

-----
To test this locally, I started a standard Fedora 34 cloud image VM, which my ssh config knows as `c`, created a simple inventory:
```
❱❱❱ cat /tmp/i 
[all]
c
```
and then ran

    ansible-playbook -i /tmp/i tests_default.yml

in the tests/ directory. This works fine. Now I would like to see how that looks in your CI, as these integration tests don't run by default (as in #33), or there are a lot of failures (as in #32, although that looked infra related).

Also, is this general shape for the tests okay? I am planning to add some more, like a tests/test_config.yml for the config writer. Then I'd add a feature to directly specify a banner test (which will create a banner file and point `cockpit_config.Session.Banner` to that), as discussed in our recent meeting.

After that I feel ready to address the bigger point of adding certificate support. But this really should be in CI properly first -- right now there are zero assertions beyond "the role does not fail".