### PR TITLE
tests: Generate self-signed certificate for RHEL >= 8

### DIFF
--- a/tests/tests_certificate.yml
+++ b/tests/tests_certificate.yml
@@ -25,10 +25,7 @@
   roles:
     - linux-system-roles.cockpit
 
-# self-signed is broken (https://github.com/linux-system-roles/certificate/issues/98),
-# and has too restrictive keyUsage so that using the certificate as CA is not allowed
-# (https://github.com/linux-system-roles/certificate/issues/99), thus use "local"
-- name: Generate local certmonger certificate
+- name: Generate self-signed certmonger certificate
   hosts: all
   tasks:
     - name: Collect installed package versions
@@ -52,24 +49,16 @@
             certificate_requests:
               - name: /etc/cockpit/ws-certs.d/monger-cockpit
                 dns: ['localhost', 'www.example.com']
-                ca: local
+                ca: self-sign
                 group: cockpit-ws
 
         #
         # Validate installation
         #
 
-        # ugh, is there really no better way to do that?
-        - name: Get PEM of certmonger's local CA
-          command:
-            cmd: >
-              openssl pkcs12 -in /var/lib/certmonger/local/creds -out /var/lib/certmonger/local/ca.pem
-              -nokeys -nodes -passin pass:""
-            creates: /var/lib/certmonger/local/ca.pem
-
         - name: test - cockpit works with TLS and expected certificate
           command:
-            cmd: curl --cacert /var/lib/certmonger/local/ca.pem https://localhost:9090
+            cmd: curl --cacert /etc/cockpit/ws-certs.d/monger-cockpit.crt https://localhost:9090
             # ansible 2.11's uri module has ca_path, but that's still too new for us
             warn: false
           changed_when: false


### PR DESCRIPTION
`ca: self-sign` is only broken on RHEL/CentOS 7, but works everywhere
else. So let's use it in tests_certificate.yml to cover this case as
well, and make sure it does not break again.

tests_certificate_runafter.yml still needs to keep `ca: local` and the
additional CA retrieval step, but it doesn't hurt to cover that mode.

-------

This exposes a set of problems and is still blocked, but filing an early draft to get CI feedback.

 - [x] Builds on top of PR #36 
 - [x] https://github.com/linux-system-roles/certificate/pull/97
 - [x] Rebase on top of #40 after landing
 - [x] Decide whether to move from self-sign to local due to https://github.com/linux-system-roles/certificate/issues/98 and https://github.com/linux-system-roles/certificate/issues/99
 - Add documentation: PR #43