### PR TITLE
Document how to generate a web server certificate, various small documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cockpit
 ![CI Testing](https://github.com/linux-system-roles/cockpit/workflows/tox/badge.svg)
 
-Installs and configures the Cockpit Web Console for distributions that support it, such as RHEL, Fedora, and a few others.
+Installs and configures the Cockpit Web Console for distributions that support it, such as RHEL, CentOS, Fedora, Debian, and Ubuntu.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs and configures the Cockpit Web Console for distributions that support i
 ## Requirements
 
   - RHEL/CentOS 7.x depend on the Extras repository being enabled.
-  - Recommended to use linux-system-roles.firewall to make the Web Console available remotely.
+  - Recommended to use [`linux-system-roles.firewall`](https://github.com/linux-system-roles/firewall/) to make the Web Console available remotely.
 
 ## Role Variables
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,33 @@ Boolean variable to control if Cockpit should be started/running (default yes).
 ```
 Configure settings in the /etc/cockpit/cockpit.conf file.  See [`man cockpit.conf`](https://cockpit-project.org/guide/latest/cockpit.conf.5.html) for a list of available settings.  Previous settings will be lost, even if they are not specified in the role variable (no attempt is made to preserve or merge the previous settings, the configuration file is replaced entirely).
 
+## Certificate setup
+
+By default, Cockpit creates a self-signed certificate for itself on first startup. This should [be customized](https://cockpit-project.org/guide/latest/https.html) for environments which use real certificates. It is recommended to use the [linux-system-roles.certificate role](https://github.com/linux-system-roles/certificate/) for that. If your machines are joined to a FreeIPA domain, or you use certmonger in a different mode already, generate a certificate for Cockpit like this:
+
+```yaml
+    # This step is only necessary for Cockpit version < 255; in particular on RHEL/CentOS 8
+    - name: Allow certmonger to write into Cockpit's certificate directory
+      file:
+        path: /etc/cockpit/ws-certs.d/
+        state: directory
+        setype: cert_t
+
+    - name: Generate Cockpit web server certificate
+      include_role:
+        name: linux-system-roles.certificate
+      vars:
+        certificate_requests:
+          - name: /etc/cockpit/ws-certs.d/monger-cockpit
+            dns: ['localhost', 'www.example.com']
+            ca: ipa
+            group: cockpit-ws
+```
+
+You can also use `ca: self-sign` or `ca: local` depending on your certmonger usage, see the [linux-system-roles.certificate documentation](https://github.com/linux-system-roles/certificate/#cas-and-providers) for details.
+
+Note that this does *not* work on RHEL/CentOS 7.
+
 ## Example Playbooks
 The most simple example.
 ```yaml

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Boolean variable to control if Cockpit should be started/running (default yes).
         IdleTimeout: 15                           #Set "IdleTimeout" in "Session" section
         Banner: "/etc/motd"                       #Set "Banner" in "Session" section
 ```
-Configure settings in the /etc/cockpit/cockpit.conf file.  See "man cockpit.conf" for a list of available settings.  Previous settings will be lost, even if they are not specified in the role variable (no attempt is made to preserve or merge the previous settings, the configuration file is replaced entirely).
+Configure settings in the /etc/cockpit/cockpit.conf file.  See [`man cockpit.conf`](https://cockpit-project.org/guide/latest/cockpit.conf.5.html) for a list of available settings.  Previous settings will be lost, even if they are not specified in the role variable (no attempt is made to preserve or merge the previous settings, the configuration file is replaced entirely).
 
 ## Example Playbooks
 The most simple example.


### PR DESCRIPTION
Now that we have the necessary fixes and tests for integrating with lsr-certificates, let's document how to use that. I did not document the rather hairy `run_after:` [approach that's needed on RHEL 7](https://github.com/linux-system-roles/cockpit/blob/master/tests/tests_certificate_runafter.yml), and instead just added a note that this only works on RHEL ≥ 8.

I welcome any suggestions here, in particular for cleaning up my broken English. :wink: 

Rendered README is here: https://github.com/martinpitt/lsr-cockpit/tree/certs-doc#readme