### PR TITLE
Add option to use an existing certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cockpit_packages: full
 Boolean variable to control if Cockpit is enabled to start automatically at boot (default yes).
 
     cockpit_started: yes
-Boolean variable to control if Cockpit should be started/running (default yes). 
+Boolean variable to control if Cockpit should be started/running (default yes).
 
 
 ```yaml
@@ -83,7 +83,24 @@ Configure settings in the /etc/cockpit/cockpit.conf file.  See [`man cockpit.con
 
 ## Certificate setup
 
-By default, Cockpit creates a self-signed certificate for itself on first startup. This should [be customized](https://cockpit-project.org/guide/latest/https.html) for environments which use real certificates. It is recommended to use the [linux-system-roles.certificate role](https://github.com/linux-system-roles/certificate/) for that. If your machines are joined to a FreeIPA domain, or you use certmonger in a different mode already, generate a certificate for Cockpit like this:
+By default, Cockpit creates a self-signed certificate for itself on first startup. This should [be customized](https://cockpit-project.org/guide/latest/https.html) for environments which use real certificates.
+
+### Use an existing certificate
+
+If your server already has some certificate which you want Cockpit to use as well, point the `cockpit_cert` and `cockpit_private_key` role options to it:
+
+```yaml
+    cockpit_cert: /path/to/server.crt
+    cockpit_private_key: /path/to/server.key
+```
+
+This will create `/etc/cockpit/ws-certs.d/50-system-role.{crt,key}` symlinks.
+
+Note that this functionality requires at least Cockpit version 257, i.e. RHEL ≥ 8.6 or ≥ 9.0, or Fedora ≥ 34.
+
+### Generate a new certificate
+
+For generating a new certificate for Cockpit it is recommended to use the [linux-system-roles.certificate role](https://github.com/linux-system-roles/certificate/). If your machines are joined to a FreeIPA domain, or you use certmonger in a different mode already, generate a certificate with:
 
 ```yaml
     # This step is only necessary for Cockpit version < 255; in particular on RHEL/CentOS 8
@@ -120,7 +137,7 @@ The most simple example.
 Another example, including the role as a task to control when the action is performed.  It is also recommended to configure the firewall using the linux-system-roles.firewall role to make the service accessible.
 ```yaml
 ---
-tasks:  
+tasks:
   - name: Install RHEL/Fedora Web Console (Cockpit)
     include_role:
       name: linux-system-roles.cockpit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,3 +46,23 @@
     backup: true
   when: cockpit_config is defined
   notify: restart cockpit
+
+- name: Link to configured existing certificate
+  file:
+    src: "{{ cockpit_cert }}"
+    path: /etc/cockpit/ws-certs.d/50-system-role.crt
+    state: link
+    force: yes
+  when:
+    - cockpit_cert is defined
+    - cockpit_private_key is defined
+
+- name: Link to configured existing certificate key
+  file:
+    src: "{{ cockpit_private_key }}"
+    path: /etc/cockpit/ws-certs.d/50-system-role.key
+    state: link
+    force: yes
+  when:
+    - cockpit_cert is defined
+    - cockpit_private_key is defined

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -9,6 +9,25 @@
     - always
     - tests::cleanup
 
+- name: cleanup - find certificates
+  find:
+    paths: /etc/cockpit/ws-certs.d/
+    file_type: any
+    patterns: "*"
+  register: certs_to_delete
+  tags:
+    - always
+    - tests::cleanup
+
+- name: cleanup - certificates
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ certs_to_delete.files }}"
+  tags:
+    - always
+    - tests::cleanup
+
 - name: cleanup - config file
   file:
     path: /etc/cockpit/cockpit.conf

--- a/tests/tests_certificate_existing.yml
+++ b/tests/tests_certificate_existing.yml
@@ -1,0 +1,52 @@
+---
+- name: Test using an existing certificate with cockpit
+  hosts: all
+  roles:
+    - role: linux-system-roles.cockpit
+      vars:
+        cockpit_packages: minimal
+        cockpit_cert: /etc/myserver.crt
+        cockpit_private_key: /etc/myserver.key
+
+  tasks:
+    - name: Collect installed package versions
+      package_facts:
+
+    - name: Check if cockpit is new enough (at least 257) to support existing certificates
+      when: ansible_facts.packages['cockpit-ws'][0].version | int >= 257
+      block:
+        - name: create test certificate key
+          command: openssl ecparam -name secp521r1 -genkey -out /etc/myserver.key
+          args:
+            creates: /etc/myserver.key
+
+        - name: create test certificate cert
+          command: openssl req -new -x509 -key /etc/myserver.key -subj '/CN=localhost' -out /etc/myserver.crt -days 365
+          args:
+            creates: /etc/myserver.crt
+
+        - name: test - cockpit works with TLS and expected certificate
+          command:
+            cmd: curl --cacert /etc/myserver.crt https://localhost:9090
+            # ansible 2.11's uri module has ca_path, but that's still too new for us
+            warn: false
+          changed_when: false
+
+      always:
+        - name: cleanup - test certificate cert
+          file:
+            path: /etc/myserver.crt
+            state: absent
+          tags:
+            - always
+            - tests::cleanup
+
+        - name: cleanup - test certificate key
+          file:
+            path: /etc/myserver.key
+            state: absent
+          tags:
+            - always
+            - tests::cleanup
+
+        - include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Add `cockpit_{certificate,key}:` role options which create
/etc/cockpit/ws-certs.d/50-system-role.{crt,key} symlinks to an existing
certificate.

This works only with cockpit >= 257, so conditionalize the test
accordingly.

Teach the generic test cleanup to remove all existing cockpit
certificates.

----

README preview: https://github.com/martinpitt/lsr-cockpit/tree/existing-cert#readme

This requires the certificate permission change in [Cockpit 257](https://cockpit-project.org/blog/cockpit-257.html). As of Nov 15, this only works in Fedora 35. The [Fedora 34 update](https://bodhi.fedoraproject.org/updates/FEDORA-2021-9b41f0e6c8) is still in updates-testing, and the RHEL 9.0 final nightly has not been re-composed yet to pick up 257 (which is through gating and in erratum since last Friday).