### PR TITLE
tests: Run cleanup on failures as well

### DIFF
--- a/tests/tests_certificate.yml
+++ b/tests/tests_certificate.yml
@@ -28,54 +28,57 @@
 - name: Generate self-signed certmonger certificate
   hosts: all
   tasks:
-    - name: Collect installed package versions
-      package_facts:
-
-    - name: Check if cockpit is new enough (at least 211) to support certmonger
-      when: ansible_facts.packages['cockpit-ws'][0].version | int >= 211
+    - name: tests
       block:
-        # Fixed in cockpit 255 (https://github.com/cockpit-project/cockpit/commit/6ec4881856e)
-        - name: Allow certmonger to write into Cockpit's certificate directory
-          file:
-            path: /etc/cockpit/ws-certs.d/
-            state: directory
-            setype: cert_t
+        - name: Collect installed package versions
+          package_facts:
 
-        # has to be done dynamically, as the first step checks it out
-        - name: Generate certificate with linux-system-roles.certificate
-          include_role:
-            name: linux-system-roles.certificate
-          vars:
-            certificate_requests:
-              - name: /etc/cockpit/ws-certs.d/monger-cockpit
-                dns: ['localhost', 'www.example.com']
-                ca: self-sign
-                group: cockpit-ws
+        - name: Check if cockpit is new enough (at least 211) to support certmonger
+          when: ansible_facts.packages['cockpit-ws'][0].version | int >= 211
+          block:
+            # Fixed in cockpit 255 (https://github.com/cockpit-project/cockpit/commit/6ec4881856e)
+            - name: Allow certmonger to write into Cockpit's certificate directory
+              file:
+                path: /etc/cockpit/ws-certs.d/
+                state: directory
+                setype: cert_t
 
-        #
-        # Validate installation
-        #
+            # has to be done dynamically, as the first step checks it out
+            - name: Generate certificate with linux-system-roles.certificate
+              include_role:
+                name: linux-system-roles.certificate
+              vars:
+                certificate_requests:
+                  - name: /etc/cockpit/ws-certs.d/monger-cockpit
+                    dns: ['localhost', 'www.example.com']
+                    ca: self-sign
+                    group: cockpit-ws
 
-        - name: test - cockpit works with TLS and expected certificate
-          command:
-            cmd: curl --cacert /etc/cockpit/ws-certs.d/monger-cockpit.crt https://localhost:9090
-            # ansible 2.11's uri module has ca_path, but that's still too new for us
-            warn: false
-          changed_when: false
+            #
+            # Validate installation
+            #
 
-        - name: test - get certmonger tracking status
-          command: getcert list  --tracking-only -f /etc/cockpit/ws-certs.d/monger-cockpit.crt
-          register: result
-          changed_when: false
+            - name: test - cockpit works with TLS and expected certificate
+              command:
+                cmd: curl --cacert /etc/cockpit/ws-certs.d/monger-cockpit.crt https://localhost:9090
+                # ansible 2.11's uri module has ca_path, but that's still too new for us
+                warn: false
+              changed_when: false
 
-        - name: test - ensure certificate generation succeeded
-          assert:
-            that: "'status: MONITORING' in result.stdout"
+            - name: test - get certmonger tracking status
+              command: getcert list  --tracking-only -f /etc/cockpit/ws-certs.d/monger-cockpit.crt
+              register: result
+              changed_when: false
 
-        - name: test - clean up tracked certificate
-          command: getcert stop-tracking -f /etc/cockpit/ws-certs.d/monger-cockpit.crt
-          changed_when: false
+            - name: test - ensure certificate generation succeeded
+              assert:
+                that: "'status: MONITORING' in result.stdout"
 
+            - name: test - clean up tracked certificate
+              command: getcert stop-tracking -f /etc/cockpit/ws-certs.d/monger-cockpit.crt
+              changed_when: false
+
+      always:
         - name: test - clean up generated certificate
           file:
             path: /etc/cockpit/ws-certs.d/monger-cockpit.crt
@@ -86,5 +89,5 @@
             path: /etc/cockpit/ws-certs.d/monger-cockpit.key
             state: absent
 
-    - name: test - generic cleanup
-      include_tasks: tasks/cleanup.yml
+        - name: test - generic cleanup
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_certificate_runafter.yml
+++ b/tests/tests_certificate_runafter.yml
@@ -62,52 +62,55 @@
 - name: Validate installation
   hosts: all
   tasks:
-    # ugh, is there really no better way to do that?
-    - name: Get PEM of certmonger's local CA
-      command:
-        cmd: >
-          openssl pkcs12 -in /var/lib/certmonger/local/creds -out /var/lib/certmonger/local/ca.pem
-          -nokeys -nodes -passin pass:""
-        creates: /var/lib/certmonger/local/ca.pem
+    - name: tests
+      block:
+        # ugh, is there really no better way to do that?
+        - name: Get PEM of certmonger's local CA
+          command:
+            cmd: >
+              openssl pkcs12 -in /var/lib/certmonger/local/creds -out /var/lib/certmonger/local/ca.pem
+              -nokeys -nodes -passin pass:""
+            creates: /var/lib/certmonger/local/ca.pem
 
-    - name: test - cockpit works with TLS and expected certificate
-      command:
-        cmd: curl --cacert /var/lib/certmonger/local/ca.pem https://localhost:9090
-        # ansible 2.11's uri module has ca_path, but that's still too new for us
-        warn: false
-      changed_when: false
+        - name: test - cockpit works with TLS and expected certificate
+          command:
+            cmd: curl --cacert /var/lib/certmonger/local/ca.pem https://localhost:9090
+            # ansible 2.11's uri module has ca_path, but that's still too new for us
+            warn: false
+          changed_when: false
 
-    - name: test - get certmonger tracking status
-      command: >
-        getcert list  --tracking-only -f
-        {{ __certificate_default_directory }}/certs/monger-cockpit.crt
-      register: result
-      changed_when: false
+        - name: test - get certmonger tracking status
+          command: >
+            getcert list  --tracking-only -f
+            {{ __certificate_default_directory }}/certs/monger-cockpit.crt
+          register: result
+          changed_when: false
 
-    - name: test - ensure certificate generation succeeded
-      assert:
-        that: "'status: MONITORING' in result.stdout"
+        - name: test - ensure certificate generation succeeded
+          assert:
+            that: "'status: MONITORING' in result.stdout"
 
-    - name: test - clean up tracked certificate
-      command: >
-        getcert stop-tracking -f
-        {{ __certificate_default_directory }}/certs/monger-cockpit.crt
-      changed_when: false
+        - name: test - clean up tracked certificate
+          command: >
+            getcert stop-tracking -f
+            {{ __certificate_default_directory }}/certs/monger-cockpit.crt
+          changed_when: false
 
-    - name: test - clean up generated certificate
-      file:
-        path: "{{ __certificate_default_directory }}/certs/monger-cockpit.crt"
-        state: absent
+      always:
+        - name: test - clean up generated certificate
+          file:
+            path: "{{ __certificate_default_directory }}/certs/monger-cockpit.crt"
+            state: absent
 
-    - name: test - clean up generated private key
-      file:
-        path: "{{ __certificate_default_directory }}/private/monger-cockpit.key"
-        state: absent
+        - name: test - clean up generated private key
+          file:
+            path: "{{ __certificate_default_directory }}/private/monger-cockpit.key"
+            state: absent
 
-    - name: test - clean up copied certificate
-      file:
-        path: /etc/cockpit/ws-certs.d/monger-cockpit.cert
-        state: absent
+        - name: test - clean up copied certificate
+          file:
+            path: /etc/cockpit/ws-certs.d/monger-cockpit.cert
+            state: absent
 
-    - name: test - generic cleanup
-      include_tasks: tasks/cleanup.yml
+        - name: test - generic cleanup
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -14,46 +14,49 @@
             IdleTimeout: 60
 
   tasks:
-    - meta: flush_handlers
+    - name: tests
+      block:
+        - meta: flush_handlers
 
-    - name: test - socket is enabled  # noqa 303 command-instead-of-module
-      command: systemctl is-enabled {{ __cockpit_daemon }}
-      changed_when: false
+        - name: test - socket is enabled  # noqa 303 command-instead-of-module
+          command: systemctl is-enabled {{ __cockpit_daemon }}
+          changed_when: false
 
-    - name: test - socket is not active  # noqa 303 command-instead-of-module
-      command: systemctl is-active {{ __cockpit_daemon }}
-      register: result
-      failed_when: result is succeeded
-      changed_when: false
+        - name: test - socket is not active  # noqa 303 command-instead-of-module
+          command: systemctl is-active {{ __cockpit_daemon }}
+          register: result
+          failed_when: result is succeeded
+          changed_when: false
 
-    - package_facts:
+        - package_facts:
 
-    - name: test - cockpit-bridge is installed
-      fail:
-        msg: cockpit-bridge is not installed
-      when: "'cockpit-bridge' not in ansible_facts.packages"
+        - name: test - cockpit-bridge is installed
+          fail:
+            msg: cockpit-bridge is not installed
+          when: "'cockpit-bridge' not in ansible_facts.packages"
 
-    - name: test - cockpit metapackage is not installed
-      fail:
-        msg: cockpit is unexpectedly installed
-      when: "'cockpit' in ansible_facts.packages"
+        - name: test - cockpit metapackage is not installed
+          fail:
+            msg: cockpit is unexpectedly installed
+          when: "'cockpit' in ansible_facts.packages"
 
-    - name: test - write expected configuration file
-      copy:
-        content: |+
-          #
-          # Ansible managed
-          #
-          [Session]
-          IdleTimeout = 60
+        - name: test - write expected configuration file
+          copy:
+            content: |+
+              #
+              # Ansible managed
+              #
+              [Session]
+              IdleTimeout = 60
 
-          [WebService]
-          LoginTitle = hello world
+              [WebService]
+              LoginTitle = hello world
 
-        dest: /run/cockpit.conf.expected
+            dest: /run/cockpit.conf.expected
 
-    - name: test - compare generated with expected configuration file
-      command: diff -u /run/cockpit.conf.expected /etc/cockpit/cockpit.conf
-      changed_when: false
+        - name: test - compare generated with expected configuration file
+          command: diff -u /run/cockpit.conf.expected /etc/cockpit/cockpit.conf
+          changed_when: false
 
-    - include_tasks: tasks/cleanup.yml
+      always:
+        - include_tasks: tasks/cleanup.yml

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -5,24 +5,27 @@
     - linux-system-roles.cockpit
 
   tasks:
-    - name: test - socket is active  # noqa 303 command-instead-of-module
-      command: systemctl is-active {{ __cockpit_daemon }}
-      changed_when: false
+    - name: tests
+      block:
+        - name: test - socket is active  # noqa 303 command-instead-of-module
+          command: systemctl is-active {{ __cockpit_daemon }}
+          changed_when: false
 
-    - name: test - socket is enabled  # noqa 303 command-instead-of-module
-      command: systemctl is-enabled {{ __cockpit_daemon }}
-      changed_when: false
+        - name: test - socket is enabled  # noqa 303 command-instead-of-module
+          command: systemctl is-enabled {{ __cockpit_daemon }}
+          changed_when: false
 
-    - name: test - cockpit works with TLS
-      get_url:
-        dest: /run/out
-        url: https://localhost:9090
-        validate_certs: no
+        - name: test - cockpit works with TLS
+          get_url:
+            dest: /run/out
+            url: https://localhost:9090
+            validate_certs: no
 
-    - name: test - no configuration file
-      stat:
-        path: /etc/cockpit/cockpit.conf
-      register: result
-      failed_when: result.stat.exists
+        - name: test - no configuration file
+          stat:
+            path: /etc/cockpit/cockpit.conf
+          register: result
+          failed_when: result.stat.exists
 
-    - include_tasks: tasks/cleanup.yml
+      always:
+        - include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Wrap tests into block:/always: so that the cleanup steps happen on
failed tests as well.

----

@richm : As discussed in your meeting last week. My previous PR #46 already uses that approach, this PR retrofits it for the existing tests.