### PR TITLE
Test "cockpit_packages: full" scenario

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -4,6 +4,7 @@
       # everything else depends on one of these two, so will be removed along
       - cockpit-bridge
       - cockpit-ws
+      - cockpit-doc
     state: absent
   tags:
     - always

--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -1,0 +1,41 @@
+---
+- name: "Test cockpit_packages: full"
+  hosts: all
+  tasks:
+    - name: tests
+      block:
+        - include_role:
+            name: linux-system-roles.cockpit
+          vars:
+            cockpit_packages: full
+
+        - meta: flush_handlers
+
+        - package_facts:
+
+        # basic package (part of minimal)
+        - name: test - cockpit-system is installed
+          fail:
+            msg: cockpit-system is not installed
+          when: "'cockpit-system' not in ansible_facts.packages"
+
+        # metapackage (part of default)
+        - name: test - cockpit metapackage is installed
+          fail:
+            msg: cockpit is not installed
+          when: "'cockpit' not in ansible_facts.packages"
+
+        # extra package (part of full)
+        - name: test - cockpit-pcp is installed
+          fail:
+            msg: cockpit-pcp is not installed
+          when: "'cockpit-pcp' not in ansible_facts.packages"
+
+        # another extra package (part of full)
+        - name: test - cockpit-doc is installed
+          fail:
+            msg: cockpit-doc is not installed
+          when: "'cockpit-doc' not in ansible_facts.packages"
+
+      always:
+        - include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
This has bug reports such as [1], ensure that this generally works
everywhere.

[1] https://github.com/linux-system-roles/cockpit/issues/51

----

This works fine for me locally on RHEL 8.6 and Fedora 35, let's check on the other's. But #51 was reported against RHEL 8.5, so apparently something more special happens on Terry's machine.