### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vault.yml
 *.swp
 *.swo
 tests/roles/linux-system-roles.certificate/
+.tox/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,5 @@
-- name: Set version specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "default.yml"
+- name: Ensure ansible_facts and variables used by role
+  include_tasks: tasks/set_vars.yml
 
 - name: Enable the Extras repository on RHEL 7
   when:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,15 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__cockpit_required_facts) == __cockpit_required_facts
+
+- name: Set version specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+    - "default.yml"

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,25 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.cockpit
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __cockpit_packages_default }}"
+        state: present
+
+    - name: Remove undesired Cockpit packages
+      package:
+        name: "{{ __cockpit_packages_exclude }}"
+        state: absent
+      when: __cockpit_packages_exclude is defined
+
+    # NOTE: Removed packages will still be in the local package cache
+    # and when installed will be installed from the local disk
+    - name: Remove cockpit metapackage for config test
+      package:
+        name: cockpit
+        state: absent

--- a/tests/tests_certificate_runafter.yml
+++ b/tests/tests_certificate_runafter.yml
@@ -2,9 +2,8 @@
 # This approach uses a `run_after:` shell script. This works everywhere,
 # including RHEL/CentOS 7, but is hackish and non-obvious in `getcert list`.
 # tests_certificate.yml covers a cleaner approach.
-- name: test - local setup
-  hosts: 127.0.0.1
-  gather_facts: false
+- name: test certificate issuance with run_after shell script
+  hosts: all
   tasks:
     - name: Download current linux-system-roles.certificate
       git:
@@ -17,20 +16,17 @@
       when:
         - lookup('env', 'BEAKERLIB') | length == 0
         - not 'roles/linux-system-roles.certificate' is exists
+      delegate_to: localhost
 
-- name: Install cockpit
-  hosts: all
-  vars:
-    cockpit_packages: minimal
-  roles:
-    - linux-system-roles.cockpit
+    - name: Install cockpit
+      vars:
+        cockpit_packages: minimal
+      include_role:
+        name: linux-system-roles.cockpit
 
 # self-signed is broken (https://github.com/linux-system-roles/certificate/issues/98),
 # and has too restrictive keyUsage so that using the certificate as CA is not allowed
 # (https://github.com/linux-system-roles/certificate/issues/99), thus use "local"
-- name: Generate local certmonger certificate
-  hosts: all
-  tasks:
     # Fixed in cockpit 255 (https://github.com/cockpit-project/cockpit/commit/6ec4881856e)
     - name: Allow certmonger to write into Cockpit's certificate directory
       file:
@@ -42,6 +38,7 @@
     - name: Generate certificate with linux-system-roles.certificate
       include_role:
         name: linux-system-roles.certificate
+        public: true
       vars:
         certificate_requests:
           - name: monger-cockpit
@@ -59,10 +56,7 @@
               chmod 640 $DEST
               chown root:cockpit-ws $DEST
 
-- name: Validate installation
-  hosts: all
-  tasks:
-    - name: tests
+    - name: Validate installation
       block:
         # ugh, is there really no better way to do that?
         - name: Get PEM of certmonger's local CA

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,6 +1,7 @@
 ---
 - name: Test role with default options
   hosts: all
+  gather_facts: false
   roles:
     - linux-system-roles.cockpit
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,3 +9,10 @@ __cockpit_package_types:
   - minimal
   - default
   - full
+
+__cockpit_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family
+  - pkg_mgr


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
