### PR TITLE
Add customization of port

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ansible
-        run: sudo apt install -y ansible
+        run: |
+            sudo apt update
+            sudo apt install -y ansible
 
       - name: Run test playbook
         run: |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Boolean variable to control if Cockpit should be started/running (default yes).
 ```
 Configure settings in the /etc/cockpit/cockpit.conf file.  See [`man cockpit.conf`](https://cockpit-project.org/guide/latest/cockpit.conf.5.html) for a list of available settings.  Previous settings will be lost, even if they are not specified in the role variable (no attempt is made to preserve or merge the previous settings, the configuration file is replaced entirely).
 
+    cockpit_port: 9090
+Cockpit runs on port 9090 by default. You can change the port with this option.
+
+Note that the default SELinux policy does not allow Cockpit to listen to anything else than port 9090, so you need to allow that first, with e.g.
+
+    semanage port -m -t websm_port_t -p tcp 443
+
+for ports that are already defined in the SELinux policy, such as 443, or
+
+    semanage port -a -t websm_port_t -p tcp 9999
+
+otherwise.
+
+See the [Cockpit guide](https://cockpit-project.org/guide/latest/listen.html#listen-systemd) for details.
+
 ## Certificate setup
 
 By default, Cockpit creates a self-signed certificate for itself on first startup. This should [be customized](https://cockpit-project.org/guide/latest/https.html) for environments which use real certificates.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
 # handlers file for cockpit
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+
 - name: restart cockpit
   service:
     name: "{{ __cockpit_daemon }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,38 @@
     - "setup-{{ ansible_pkg_mgr }}.yml"
     - "setup-default.yml"
 
+- name: Create custom port configuration file directory
+  file:
+    path: /etc/systemd/system/cockpit.socket.d/
+    owner: root
+    group: root
+    state: directory
+  when: cockpit_port is defined
+
+- name: Create custom port configuration file
+  copy:
+    dest: /etc/systemd/system/cockpit.socket.d/listen.conf
+    mode: 0644
+    owner: root
+    group: root
+    content: |
+      [Socket]
+      ListenStream=
+      ListenStream={{ cockpit_port }}
+  when: cockpit_port is defined
+  notify:
+    - reload systemd
+    - restart cockpit
+
+- name: Clean up port configuration file for undefined custom port
+  file:
+    path: /etc/systemd/system/cockpit.socket.d/listen.conf
+    state: absent
+  when: cockpit_port is not defined
+  notify:
+    - reload systemd
+    - restart cockpit
+
 - name: Ensure Cockpit Web Console is started/stopped and enabled/disabled
   service:
     name: "{{ __cockpit_daemon }}"

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -36,3 +36,18 @@
   tags:
     - always
     - tests::cleanup
+
+- name: cleanup - port customization
+  file:
+    path: /etc/systemd/system/cockpit.socket.d/
+    state: absent
+  tags:
+    - always
+    - tests::cleanup
+
+- name: cleanup - reload systemd
+  systemd:
+    daemon_reload: true
+  tags:
+    - always
+    - tests::cleanup

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -22,6 +22,14 @@
             url: https://localhost:9090
             validate_certs: no
 
+        - name: test - HTTP response is something sensible
+          command: grep 'id="login-user-input"' /run/out
+
+        - name: test - clean up output file
+          file:
+            path: /run/out
+            state: absent
+
         - name: test - no configuration file
           stat:
             path: /etc/cockpit/cockpit.conf

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -36,5 +36,11 @@
           register: result
           failed_when: result.stat.exists
 
+        - name: test - no port configuration file
+          stat:
+            path: /etc/systemd/system/cockpit.socket.d
+          register: result
+          failed_when: result.stat.exists
+
       always:
         - include_tasks: tasks/cleanup.yml

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -1,0 +1,43 @@
+---
+- name: Test cockpit_* role options
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: tests
+      block:
+        - name: Allow cockpit to own customized port in SELinux
+          shell: if selinuxenabled; then semanage port -m -t websm_port_t -p tcp 443; fi
+
+        - name: Run cockpit role
+          include_role:
+            name: linux-system-roles.cockpit
+          vars:
+            cockpit_packages: minimal
+            cockpit_port: 443
+
+        - meta: flush_handlers
+
+        - name: test - cockpit works on customized port
+          get_url:
+            dest: /run/out
+            url: https://localhost
+            validate_certs: no
+
+        - name: test - HTTP response is something sensible
+          command: grep 'id="login-user-input"' /run/out
+
+        - name: test - cockpit does not listen on port 9090
+          get_url:
+            dest: /run/out
+            url: https://localhost:9090
+            validate_certs: no
+          register: result
+          failed_when: result is succeeded
+
+        - name: test - clean up output file
+          file:
+            path: /run/out
+            state: absent
+
+      always:
+        - include_tasks: tasks/cleanup.yml

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -1,10 +1,43 @@
 ---
 - name: Test cockpit_* role options
   hosts: all
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: tests
       block:
+        - name: Install SELinux python2 tools
+          package:
+            name:
+              - libselinux-python
+              - policycoreutils-python
+            state: present
+          when: "ansible_python_version is version('3', '<')"
+
+        - name: Install SELinux python3 tools
+          package:
+            name:
+              - libselinux-python3
+              - policycoreutils-python3
+            state: present
+          when: "ansible_python_version is version('3', '>=')"
+
+        - name: Install SELinux python3 tools
+          package:
+            name:
+              - libselinux-python3
+              - policycoreutils-python3
+            state: present
+          when: "ansible_python_version is version('3', '>=')"
+
+        - name: Install SELinux tool semanage
+          package:
+            name:
+              - policycoreutils-python-utils
+            state: present
+          when: ansible_distribution == "Fedora" or
+            ( ansible_distribution_major_version | int > 7 and
+              ansible_distribution in ["CentOS", "RedHat", "Rocky"] )
+
         - name: Allow cockpit to own customized port in SELinux
           shell: if selinuxenabled; then semanage port -m -t websm_port_t -p tcp 443; fi
 


### PR DESCRIPTION
Introduce a `cockpit_port` variable which changes the default port 9090,
as per https://cockpit-project.org/guide/latest/listen.html#listen-systemd

This requires an extra step with SELinux: It only allows cockpit to own port
9090, so for any other port the user needs to adjust the policy first. As this
is outside of what the cockpit role ought to mess with, only document it and do
that in the tests.

Fixes #63 

------

Documentation preview: https://github.com/martinpitt/lsr-cockpit/tree/custom-port