### PR TITLE
[citest skip] workflows: Add integration-tests for Ubuntu 22.04

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,14 +7,21 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release:
+          - ubuntu-20.04
+          - ubuntu-22.04
+    runs-on: '${{ matrix.release }}'
     timeout-minutes: 30
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
       - name: Install Ansible
-        run: sudo apt install -y ansible
+        run: |
+          sudo apt update
+          sudo apt install -y ansible
 
       - name: Run test playbook
         run: |


### PR DESCRIPTION
The current LTS 22.04 is the more interesting target. This detects bugs
like [1]. Keep 20.04 running as well for the time being.

[1] https://github.com/linux-system-roles/certificate/pull/130

----

 - Requires https://github.com/linux-system-roles/certificate/pull/130 to land first