### PR TITLE
tests: Don't install selinux-python on Debian/Ubuntu

### DIFF
--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -11,7 +11,8 @@
               - libselinux-python
               - policycoreutils-python
             state: present
-          when: "ansible_python_version is version('3', '<')"
+          when: ( ansible_python_version is version('3', '<') and
+                  ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"] )
 
         - name: Install SELinux python3 tools
           package:
@@ -19,15 +20,8 @@
               - libselinux-python3
               - policycoreutils-python3
             state: present
-          when: "ansible_python_version is version('3', '>=')"
-
-        - name: Install SELinux python3 tools
-          package:
-            name:
-              - libselinux-python3
-              - policycoreutils-python3
-            state: present
-          when: "ansible_python_version is version('3', '>=')"
+          when: ( ansible_python_version is version('3', '>=') and
+                  ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"] )
 
         - name: Install SELinux tool semanage
           package:


### PR DESCRIPTION
libselinux-python3 does not exist in Debian/Ubuntu, so only install it
in Fedora/RedHat based distributions.

Drop the duplicated rule.

---

Fixes [this regression](https://github.com/linux-system-roles/cockpit/runs/7601244368?check_suite_focus=true#step:4:909) of the integration test.