### PR TITLE
Automatically handle SELinux for port customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,7 @@ Configure settings in the /etc/cockpit/cockpit.conf file.  See [`man cockpit.con
 
     cockpit_port: 9090
 Cockpit runs on port 9090 by default. You can change the port with this option.
-
-Note that the default SELinux policy does not allow Cockpit to listen to anything else than port 9090, so you need to allow that first, with e.g.
-
-    semanage port -m -t websm_port_t -p tcp 443
-
-for ports that are already defined in the SELinux policy, such as 443, or
-
-    semanage port -a -t websm_port_t -p tcp 9999
-
-otherwise.
-
-See the [Cockpit guide](https://cockpit-project.org/guide/latest/listen.html#listen-systemd) for details.
+This will also allow cockpit to own the given port in the SELinux policy, using [linux-system-roles.selinux](https://github.com/linux-system-roles/selinux/). See the [Cockpit guide](https://cockpit-project.org/guide/latest/listen.html#listen-systemd) for details.
 
 ## Certificate setup
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,22 @@
     - reload systemd
     - restart cockpit
 
+# the selinux role does not like being run on systems without SELinux
+- name: Check if SELinux is enabled
+  command: selinuxenabled
+  failed_when: false
+  changed_when: false
+  register: selinuxenabled
+  when: cockpit_port is defined
+
+- name: Allow cockpit to own custom port in SELinux policy
+  include_role:
+    name: linux-system-roles.selinux
+  vars:
+    selinux_ports:
+      - { ports: '{{ cockpit_port }}', proto: 'tcp', setype: 'websm_port_t', state: 'present' }
+  when: cockpit_port is defined and selinuxenabled.rc == 0
+
 - name: Clean up port configuration file for undefined custom port
   file:
     path: /etc/systemd/system/cockpit.socket.d/listen.conf

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -1,40 +1,26 @@
 ---
-- name: Test cockpit_* role options
+- name: test - local setup
+  hosts: 127.0.0.1
+  gather_facts: false
+  tasks:
+    - name: Download current linux-system-roles.selinux
+      git:
+        repo: https://github.com/linux-system-roles/selinux/
+        dest: roles/linux-system-roles.selinux
+        version: master
+        depth: 1
+      become: false
+      # skip this for RHEL downstream tests, which define $BEAKERLIB
+      when:
+        - lookup('env', 'BEAKERLIB') | length == 0
+        - not 'roles/linux-system-roles.selinux' is exists
+
+- name: Test cockpit_port option
   hosts: all
   gather_facts: true
   tasks:
     - name: tests
       block:
-        - name: Install SELinux python2 tools
-          package:
-            name:
-              - libselinux-python
-              - policycoreutils-python
-            state: present
-          when: ( ansible_python_version is version('3', '<') and
-                  ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"] )
-
-        - name: Install SELinux python3 tools
-          package:
-            name:
-              - libselinux-python3
-              - policycoreutils-python3
-            state: present
-          when: ( ansible_python_version is version('3', '>=') and
-                  ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"] )
-
-        - name: Install SELinux tool semanage
-          package:
-            name:
-              - policycoreutils-python-utils
-            state: present
-          when: ansible_distribution == "Fedora" or
-            ( ansible_distribution_major_version | int > 7 and
-              ansible_distribution in ["CentOS", "RedHat", "Rocky"] )
-
-        - name: Allow cockpit to own customized port in SELinux
-          shell: if selinuxenabled; then semanage port -m -t websm_port_t -p tcp 443; fi
-
         - name: Run cockpit role
           include_role:
             name: linux-system-roles.cockpit


### PR DESCRIPTION
Use the selinux system role for this.

---

Follow-up from PR #67.