### PR TITLE
Use the firewall role and the selinux role from the cockpit role

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Installs and configures the Cockpit Web Console for distributions that support i
   - RHEL/CentOS 7.x depend on the Extras repository being enabled.
   - Recommended to use [`linux-system-roles.firewall`](https://github.com/linux-system-roles/firewall/) to make the Web Console available remotely.
 
-  - The role requires the `firewall` role from the `fedora.linux_system_roles`
-    collection, if `cockpit_manage_firewall` is set to `yes`.
-    Please see also `cockpit_manage_firewall` in [`Role Variables`](#role-variables).
+  - The role requires the `firewall` role and the `selinux` role from the
+    `fedora.linux_system_roles` collection, if `cockpit_manage_firewall`
+    and `cockpit_manage_selinux` is set to yes, respectively.
+    Please see also `cockpit_manage_firewall` and `cockpit_manage_selinux`
+    in [`Role Variables`](#role-variables).
 
     If `cockpit` is a role from the `fedora.linux_system_roles` collection
     or from the Fedora RPM package, the requirement is already satisfied.
@@ -106,17 +108,23 @@ role directly.
 NOTE: This functionality is supported only when the managed host's `os_family`
 is `RedHat`.
 
-Note that the default SELinux policy does not allow Cockpit to listen to anything else than port 9090, so you need to allow that first, with e.g.
+    cockpit_manage_selinux: no
+Boolean flag allowing to configure selinux using the selinux role.
+The default SELinux policy does not allow Cockpit to listen to anything else
+than port 9090. If you change the port, enable this to use the selinux role
+to set the correct port permissions (websm_port_t).
+If the variable is set to no, the `cockpit` role does not manage the
+SELinux permissions of the cockpit port.
 
-    semanage port -m -t websm_port_t -p tcp 443
+NOTE: `cockpit_manage_selinux` is limited to *adding* policy.
+It cannot be used for *removing* policy.
+If you want to remove policy, you will need to use the selinux system
+role directly.
 
-for ports that are already defined in the SELinux policy, such as 443, or
+NOTE: This functionality is supported only when the managed host's `os_family`
+is `RedHat`.
 
-    semanage port -a -t websm_port_t -p tcp 9999
-
-otherwise.
-
-See the [Cockpit guide](https://cockpit-project.org/guide/latest/listen.html#listen-systemd) for details.
+See also the [Cockpit guide](https://cockpit-project.org/guide/latest/listen.html#listen-systemd) for details.
 
 ## Certificate setup
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Installs and configures the Cockpit Web Console for distributions that support i
   - RHEL/CentOS 7.x depend on the Extras repository being enabled.
   - Recommended to use [`linux-system-roles.firewall`](https://github.com/linux-system-roles/firewall/) to make the Web Console available remotely.
 
+  - The role requires the `firewall` role from the `fedora.linux_system_roles`
+    collection, if `cockpit_manage_firewall` is set to `yes`.
+    Please see also `cockpit_manage_firewall` in [`Role Variables`](#role-variables).
+
+    If `cockpit` is a role from the `fedora.linux_system_roles` collection
+    or from the Fedora RPM package, the requirement is already satisfied.
+
+    Otherwise, please run the following command line to install the collection.
+    ```
+    ansible-galaxy collection install -r meta/collection-requirements.yml
+    ```
+
 ## Role Variables
 
 Available variables per distribution are listed below, along with default values (see `defaults/main.yml`):
@@ -80,6 +92,19 @@ Configure settings in the /etc/cockpit/cockpit.conf file.  See [`man cockpit.con
 
     cockpit_port: 9090
 Cockpit runs on port 9090 by default. You can change the port with this option.
+
+    cockpit_manage_firewall: no
+Boolean variable to control the `cockpit` firewall service with the `firewall` role.
+If the variable is set to `no`, the `cockpit` role does not manage the firewall.
+Default to `no`.
+
+NOTE: `cockpit_manage_firewall` is limited to *adding* ports.
+It cannot be used for *removing* ports.
+If you want to remove ports, you will need to use the firewall system
+role directly.
+
+NOTE: This functionality is supported only when the managed host's `os_family`
+is `RedHat`.
 
 Note that the default SELinux policy does not allow Cockpit to listen to anything else than port 9090, so you need to allow that first, with e.g.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,6 @@ cockpit_port: null
 
 # If yes, manage the cockpit ports using the firewall role.
 cockpit_manage_firewall: no
+
+# If yes, manage the cockpit ports using the selinux role.
+cockpit_manage_selinux: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ __cockpit_daemon: cockpit.socket
 # __cockpit_packages_default    set in vars/*
 # __cockpit_packages_full       set in vars/*
 # __cockpit_packages_minimal    set in vars/*
+
+# Cockpit runs on port 9090 by default.
+cockpit_port: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,6 @@ __cockpit_daemon: cockpit.socket
 
 # Cockpit runs on port 9090 by default.
 cockpit_port: null
+
+# If yes, manage the cockpit ports using the firewall role.
+cockpit_manage_firewall: no

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+collections:
+  - fedora.linux_system_roles

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -4,7 +4,7 @@
   include_role:
     name: fedora.linux_system_roles.firewall
   vars:
-    _cockpit_port: "{{ cockpit_port if cockpit_port is defined else 9090 }}"
+    _cockpit_port: "{{ cockpit_port if cockpit_port is not none else 9090 }}"
     _cockpit_port_proto: "{{ _cockpit_port }}/tcp"
     firewall: "{{ [{'service': 'cockpit', 'state': 'enabled'}]
                   if (_cockpit_port | int) == 9090 else

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure the cockpit service is enabled
+  include_role:
+    name: fedora.linux_system_roles.firewall
+  vars:
+    _cockpit_port: "{{ cockpit_port if cockpit_port is defined else 9090 }}"
+    _cockpit_port_proto: "{{ _cockpit_port }}/tcp"
+    firewall: "{{ [{'service': 'cockpit', 'state': 'enabled'}]
+                  if (_cockpit_port | int) == 9090 else
+                  [{'port': _cockpit_port_proto, 'state': 'enabled'}] }}"
+  when:
+    - cockpit_manage_firewall | bool
+    - ansible_facts['os_family'] == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     owner: root
     group: root
     state: directory
-  when: cockpit_port is defined
+  when: cockpit_port is not none
 
 - name: Create custom port configuration file
   copy:
@@ -42,7 +42,7 @@
       [Socket]
       ListenStream=
       ListenStream={{ cockpit_port }}
-  when: cockpit_port is defined
+  when: cockpit_port is not none
   notify:
     - reload systemd
     - restart cockpit
@@ -51,7 +51,7 @@
   file:
     path: /etc/systemd/system/cockpit.socket.d/listen.conf
     state: absent
-  when: cockpit_port is not defined
+  when: cockpit_port is none
   notify:
     - reload systemd
     - restart cockpit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,9 @@
 - name: Configure firewall
   include_tasks: firewall.yml
 
+- name: Configure selinux
+  include_tasks: selinux.yml
+
 - name: Create custom port configuration file directory
   file:
     path: /etc/systemd/system/cockpit.socket.d/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,9 @@
     - "setup-{{ ansible_pkg_mgr }}.yml"
     - "setup-default.yml"
 
+- name: Configure firewall
+  include_tasks: firewall.yml
+
 - name: Create custom port configuration file directory
   file:
     path: /etc/systemd/system/cockpit.socket.d/

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure the service and the ports status with the selinux role
+  include_role:
+    name: fedora.linux_system_roles.selinux
+  vars:
+    selinux_ports: "{{ [{'ports': cockpit_port, 'proto': 'tcp',
+                         'setype': 'websm_port_t',
+                         'state': 'present', 'local': 'true'}] }}"
+  when:
+    - cockpit_manage_selinux | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - cockpit_port is not none

--- a/tests/tasks/check_port.yml
+++ b/tests/tasks/check_port.yml
@@ -2,7 +2,7 @@
 ---
 - block:
     - block:
-        - name: Check firewall port status when cockpit_manage_firewall is true
+        - name: Check firewall port status when cockpit_manage_firewall is yes
           command: firewall-cmd --list-service
           register: _result
           failed_when: "'cockpit' not in _result.stdout"
@@ -10,7 +10,7 @@
           when:
             - _cockpit_port | int == 9090
 
-        - name: Check firewall port status when cockpit_manage_firewall is true
+        - name: Check firewall port status when cockpit_manage_firewall is yes
           command: firewall-cmd --list-port
           register: _result
           failed_when: "'{{ _cockpit_port }}/tcp' not in _result.stdout"
@@ -19,7 +19,18 @@
             - _cockpit_port | int != 9090
       when:
         - cockpit_manage_firewall | bool
+
+    - block:
+        - name: Install SELinux tools
+          include_tasks: install_selinux_tools.yml
+
+        - name: Check associated selinux ports when cockpit_manage_selinux is yes
+          shell: |-
+            set -euo pipefail
+            semanage port --list | egrep "websm_port_t *tcp" | grep "{{ _cockpit_port }}"
+          changed_when: false
+      when: cockpit_manage_selinux | bool
   vars:
-    _cockpit_port: "{{ cockpit_port if cockpit_port is defined else 9090 }}"
+    _cockpit_port: "{{ cockpit_port if cockpit_port is not none else 9090 }}"
   when:
     - ansible_facts['os_family'] == 'RedHat'

--- a/tests/tasks/check_port.yml
+++ b/tests/tasks/check_port.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+---
+- block:
+    - block:
+        - name: Check firewall port status when cockpit_manage_firewall is true
+          command: firewall-cmd --list-service
+          register: _result
+          failed_when: "'cockpit' not in _result.stdout"
+          changed_when: false
+          when:
+            - _cockpit_port | int == 9090
+
+        - name: Check firewall port status when cockpit_manage_firewall is true
+          command: firewall-cmd --list-port
+          register: _result
+          failed_when: "'{{ _cockpit_port }}/tcp' not in _result.stdout"
+          changed_when: false
+          when:
+            - _cockpit_port | int != 9090
+      when:
+        - cockpit_manage_firewall | bool
+  vars:
+    _cockpit_port: "{{ cockpit_port if cockpit_port is defined else 9090 }}"
+  when:
+    - ansible_facts['os_family'] == 'RedHat'

--- a/tests/tasks/install_selinux_tools.yml
+++ b/tests/tasks/install_selinux_tools.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Install SELinux python2 tools
+  package:
+    name:
+      - libselinux-python
+      - policycoreutils-python
+    state: present
+  when: ( ansible_python_version is version('3', '<') and
+          ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"] )
+
+- name: Install SELinux python3 tools
+  package:
+    name:
+      - libselinux-python3
+      - policycoreutils-python3
+    state: present
+  when: ( ansible_python_version is version('3', '>=') and
+          ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"] )
+
+- name: Install SELinux tool semanage
+  package:
+    name:
+      - policycoreutils-python-utils
+    state: present
+  when: ansible_distribution == "Fedora" or
+    ( ansible_distribution_major_version | int > 7 and
+      ansible_distribution in ["CentOS", "RedHat", "Rocky"] )

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -12,6 +12,8 @@
             LoginTitle: "hello world"
           Session:
             IdleTimeout: 60
+        cockpit_manage_firewall: false
+      public: true
 
   tasks:
     - name: tests
@@ -57,6 +59,9 @@
         - name: test - compare generated with expected configuration file
           command: diff -u /run/cockpit.conf.expected /etc/cockpit/cockpit.conf
           changed_when: false
+
+        - name: test - ensure cockpit_port is configured for firewall
+          include_tasks: tasks/check_port.yml
 
       always:
         - include_tasks: tasks/cleanup.yml

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -12,7 +12,8 @@
             LoginTitle: "hello world"
           Session:
             IdleTimeout: 60
-        cockpit_manage_firewall: false
+        cockpit_manage_firewall: no
+        cockpit_manage_selinux: yes
       public: true
 
   tasks:
@@ -60,7 +61,7 @@
           command: diff -u /run/cockpit.conf.expected /etc/cockpit/cockpit.conf
           changed_when: false
 
-        - name: test - ensure cockpit_port is configured for firewall
+        - name: test - ensure cockpit_port is configured for firewall and selinux
           include_tasks: tasks/check_port.yml
 
       always:

--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -9,7 +9,8 @@
             public: true
           vars:
             cockpit_packages: full
-            cockpit_manage_firewall: true
+            cockpit_manage_firewall: yes
+            cockpit_manage_selinux: no
 
         - meta: flush_handlers
 
@@ -39,7 +40,7 @@
             msg: cockpit-doc is not installed
           when: "'cockpit-doc' not in ansible_facts.packages"
 
-        - name: test - ensure cockpit_port is configured for firewall
+        - name: test - ensure cockpit_port is configured for firewall and selinux
           include_tasks: tasks/check_port.yml
 
       always:

--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -6,8 +6,10 @@
       block:
         - include_role:
             name: linux-system-roles.cockpit
+            public: true
           vars:
             cockpit_packages: full
+            cockpit_manage_firewall: true
 
         - meta: flush_handlers
 
@@ -36,6 +38,9 @@
           fail:
             msg: cockpit-doc is not installed
           when: "'cockpit-doc' not in ansible_facts.packages"
+
+        - name: test - ensure cockpit_port is configured for firewall
+          include_tasks: tasks/check_port.yml
 
       always:
         - include_tasks: tasks/cleanup.yml

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -38,7 +38,9 @@
         - name: Run cockpit role
           include_role:
             name: linux-system-roles.cockpit
+            public: true
           vars:
+            cockpit_manage_firewall: true
             cockpit_packages: minimal
             cockpit_port: 443
 
@@ -60,6 +62,9 @@
             validate_certs: no
           register: result
           failed_when: result is succeeded
+
+        - name: test - ensure cockpit_port is configured for firewall
+          include_tasks: tasks/check_port.yml
 
         - name: test - clean up output file
           file:

--- a/tests/tests_port2.yml
+++ b/tests/tests_port2.yml
@@ -5,16 +5,13 @@
   tasks:
     - name: tests
       block:
-        - name: Install SELinux tools
-          include_tasks: tasks/install_selinux_tools.yml
-
-        - name: Allow cockpit to own customized port in SELinux
-          shell: if selinuxenabled; then semanage port -m -t websm_port_t -p tcp 443; fi
-
         - name: Run cockpit role
           include_role:
             name: linux-system-roles.cockpit
+            public: true
           vars:
+            cockpit_manage_firewall: yes
+            cockpit_manage_selinux: yes
             cockpit_packages: minimal
             cockpit_port: 443
 
@@ -36,6 +33,9 @@
             validate_certs: no
           register: result
           failed_when: result is succeeded
+
+        - name: test - ensure cockpit_port is configured for firewall
+          include_tasks: tasks/check_port.yml
 
         - name: test - clean up output file
           file:


### PR DESCRIPTION
- Introduce cockpit_manage_firewall to use the firewall role to manage the cockpit service. Default to false - means the firewall role is not used.

- Introduce cockpit_manage_selinux to use the selinux role to manage the ports in the cockpit service. Assign websm_port_t to the cockpit service ports. Default to false - means the selinux role is not used.

- Add the test check task tasks/check_firewall_selinux.yml for verify the ports status.

- Add meta/collection-requirements.yml.