### PR TITLE
Clone the certificate role in the temporary dir.

### DIFF
--- a/tests/tasks/clone_cert_role.yml
+++ b/tests/tasks/clone_cert_role.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Create temp dir test
+  tempfile:
+    state: directory
+    prefix: lsr_cockpit_
+  register: __cockpit_tmp_dir
+  changed_when: false
+
+- name: Set cockpit_test_roles_dir
+  set_fact:
+    cockpit_test_roles_dir: "{{ __cockpit_tmp_dir.path }}"
+
+- name: Download current linux-system-roles.certificate
+  git:
+    repo: https://github.com/linux-system-roles/certificate/
+    dest: "{{ cockpit_test_roles_dir }}/linux-system-roles.certificate"
+    version: master
+    depth: 1
+  become: false
+  delegate_to: localhost
+  # skip this for RHEL downstream tests, which define $BEAKERLIB
+  when:
+    - lookup('env', 'BEAKERLIB') | length == 0

--- a/tests/tests_certificate.yml
+++ b/tests/tests_certificate.yml
@@ -6,17 +6,8 @@
   hosts: 127.0.0.1
   gather_facts: false
   tasks:
-    - name: Download current linux-system-roles.certificate
-      git:
-        repo: https://github.com/linux-system-roles/certificate/
-        dest: roles/linux-system-roles.certificate
-        version: master
-        depth: 1
-      become: false
-      # skip this for RHEL downstream tests, which define $BEAKERLIB
-      when:
-        - lookup('env', 'BEAKERLIB') | length == 0
-        - not 'roles/linux-system-roles.certificate' is exists
+    - name: Clone certificate role
+      include_tasks: tasks/clone_cert_role.yml
 
 - name: Install cockpit
   hosts: all
@@ -46,8 +37,9 @@
             # has to be done dynamically, as the first step checks it out
             - name: Generate certificate with linux-system-roles.certificate
               include_role:
-                name: linux-system-roles.certificate
+                name: "{{ cockpit_test_roles_dir }}/linux-system-roles.certificate"
               vars:
+                cockpit_test_roles_dir: "{{ hostvars['localhost']['cockpit_test_roles_dir'] }}"
                 certificate_requests:
                   - name: /etc/cockpit/ws-certs.d/monger-cockpit
                     dns: ['localhost', 'www.example.com']
@@ -91,3 +83,9 @@
 
         - name: test - generic cleanup
           include_tasks: tasks/cleanup.yml
+
+        - name: Clean up the tempdir
+          file:
+            path: "{{ hostvars['localhost']['cockpit_test_roles_dir'] }}"
+            state: absent
+          delegate_to: localhost

--- a/tests/tests_certificate_runafter.yml
+++ b/tests/tests_certificate_runafter.yml
@@ -5,18 +5,8 @@
 - name: test certificate issuance with run_after shell script
   hosts: all
   tasks:
-    - name: Download current linux-system-roles.certificate
-      git:
-        repo: https://github.com/linux-system-roles/certificate/
-        dest: roles/linux-system-roles.certificate
-        version: master
-        depth: 1
-      become: false
-      # skip this for RHEL downstream tests, which define $BEAKERLIB
-      when:
-        - lookup('env', 'BEAKERLIB') | length == 0
-        - not 'roles/linux-system-roles.certificate' is exists
-      delegate_to: localhost
+    - name: Clone certificate role
+      include_tasks: tasks/clone_cert_role.yml
 
     - name: Install cockpit
       vars:
@@ -37,7 +27,7 @@
     # has to be done dynamically, as the first step checks it out
     - name: Generate certificate with linux-system-roles.certificate
       include_role:
-        name: linux-system-roles.certificate
+        name: "{{ cockpit_test_roles_dir }}/linux-system-roles.certificate"
         public: true
       vars:
         certificate_requests:
@@ -108,3 +98,9 @@
 
         - name: test - generic cleanup
           include_tasks: tasks/cleanup.yml
+
+        - name: Clean up the tempdir
+          file:
+            path: "{{ cockpit_test_roles_dir }}"
+            state: absent
+          delegate_to: localhost


### PR DESCRIPTION
Following the comment https://github.com/linux-system-roles/cockpit/pull/76#issuecomment-1262432694 by @richm , clone the certificate role in the temporary dir.

Note: this is needed to make the CI tests pass.