### PR TITLE
Add README-ansible.md to refer Ansible intro page on linux-system-rol…

### DIFF
--- a/README-ansible.md
+++ b/README-ansible.md
@@ -1,0 +1,6 @@
+Introduction to Ansible for Linux System Roles
+==============================================
+
+If you are not familiar with Ansible, please see
+[Introduction to Ansible for Linux System Roles](https://linux-system-roles.github.io/documentation/intro-to-ansible-for-system-roles.html),
+where many useful links are presented.


### PR DESCRIPTION
We'd like to provide a simple Ansible introduction to users who are not familiar with Ansible. Please note that the link https://linux-system-roles.github.io/documentation/intro-to-ansible-for-system-roles.html is just for the upstream community. So, for the downstream, the README-ansible.md is to be replaced with a more official Red Hat doc or pointing to such docs.

For a more detailed background, please see https://github.com/linux-system-roles/postgresql/issues/20.