### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/cockpit.conf.j2
+++ b/templates/cockpit.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:cockpit" | comment(prefix="", postfix="") }}
 {% if cockpit_config is defined %}
 {%   for section, config in cockpit_config.items() | sort(attribute=0) %}
 [{{ section }}]

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -53,6 +53,8 @@
               #
               # Ansible managed
               #
+              # system_role:cockpit
+
               [Session]
               IdleTimeout = 60
 


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:cockpit
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.