### PR TITLE
additional ansible-lint fixes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
     - name: Enable RHEL repositories
       command: subscription-manager repos --enable rhel-7-server-extras-rpms
       when: "'rhel-7-server-extras-rpms' not in __cockpit_repolist.stdout"
+      changed_when: true
 
 - name: >-
     Manage cockpit packages using platform specific package manager

--- a/tests/tasks/check_port.yml
+++ b/tests/tasks/check_port.yml
@@ -35,6 +35,9 @@
             Check associated selinux ports when cockpit_manage_selinux is yes
           shell: |-
             set -eu
+            if set -o | grep -q pipefail; then
+              set -o pipefail  # no pipefail on debian, some ubuntu
+            fi
             semanage port --list | egrep "websm_port_t *tcp" | \
               grep "{{ _cockpit_port }}"
           changed_when: false


### PR DESCRIPTION
```
tasks/main.yml:17: no-changed-when: Commands should not change things if nothing needs doing.
```
Use `changed_when: true` so that the command will report changed if the
`when` condition is true and the command is executed.

```
tests/tasks/check_port.yml:34: risky-shell-pipe: Shells that use pipes should set the pipefail option.
```
add `pipefail` option.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
