### PR TITLE
Fix dependency for linux-system-roles.firewall

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+roles:
+  - name: linux-system-roles.firewall

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -2,7 +2,7 @@
 ---
 - name: Ensure the cockpit service is enabled
   include_role:
-    name: fedora.linux_system_roles.firewall
+    name: linux-system-roles.firewall
   vars:
     _cockpit_port: "{{ cockpit_port if cockpit_port is not none else 9090 }}"
     _cockpit_port_proto: "{{ _cockpit_port }}/tcp"


### PR DESCRIPTION
Installing this from Galaxy doesn't pull in the dependency on linux-system-roles.firewall.  Fix one typo, add requirements.yml.