### PR TITLE
ci: Remove badges from README.md prior to converting to HTML

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Ensure that version and docs directories exist
         run: mkdir -p ${{ env.RELEASE_VERSION }} docs
 
+      - name: Remove badges from README.md prior to converting to HTML
+        run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' ref_branch/README.md
+
       - name: Convert README.md to HTML and save to the version directory
         uses: docker://pandoc/core:latest
         with:

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Convert README.md to HTML and save to the version directory
+      - name: Remove badges from README.md prior to converting to HTML
+        run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md
+
+      - name: Convert README.md to HTML
         uses: docker://pandoc/core:latest
         with:
           args: >-

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![ansible-lint.yml](https://github.com/linux-system-roles/cockpit/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/cockpit/actions/workflows/ansible-lint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/cockpit/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/cockpit/actions/workflows/ansible-test.yml) [![integration-tests.yml](https://github.com/linux-system-roles/cockpit/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/linux-system-roles/cockpit/actions/workflows/integration-tests.yml) [![markdownlint.yml](https://github.com/linux-system-roles/cockpit/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/cockpit/actions/workflows/markdownlint.yml) [![woke.yml](https://github.com/linux-system-roles/cockpit/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/cockpit/actions/workflows/woke.yml)
 
----
-
 Installs and configures the Cockpit Web Console for distributions that support it, such as RHEL, CentOS, Fedora, Debian, and Ubuntu.
 
 ## Requirements


### PR DESCRIPTION
- Remove thematic break after badges
- Remove badges from README.md prior to converting to HTML

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
