### PR TITLE
refactor: improve support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,5 +22,3 @@ exclude_paths:
   - examples/roles/
 mock_roles:
   - linux-system-roles.cockpit
-mock_modules:
-  - ansible.utils.update_fact

--- a/.ostree/packages-runtime-CentOS-9.txt
+++ b/.ostree/packages-runtime-CentOS-9.txt
@@ -1,0 +1,1 @@
+cockpit-*

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,5 +2,4 @@
 ---
 collections:
   - ansible.posix
-  - ansible.utils
   - fedora.linux_system_roles

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   when:
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version == '7'
-    - ansible_facts.pkg_mgr | d() != "ansible.posix.rhel_rpm_ostree"
+    - not __cockpit_is_ostree | d(false)
   block:
     - name: List active RHEL repositories
       command:
@@ -27,7 +27,7 @@
   with_first_found:
     - "setup-{{ ansible_pkg_mgr }}.yml"
     - "setup-default.yml"
-  when: ansible_facts.pkg_mgr | d() != "ansible.posix.rhel_rpm_ostree"
+  when: not __cockpit_is_ostree | d(false)
 
 - name: Configure firewall
   include_tasks: firewall.yml

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,23 +5,17 @@
   when: __cockpit_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __cockpit_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __cockpit_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Set version specific variables
   include_vars: "{{ item }}"

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -7,7 +7,7 @@
       - cockpit-ws
       - cockpit-doc
     state: absent
-  when: ansible_facts.pkg_mgr | d() != "ansible.posix.rhel_rpm_ostree"
+  when: not __cockpit_is_ostree | d(false)
   tags:
     - always
     - tests::cleanup

--- a/tests/tasks/install_selinux_tools.yml
+++ b/tests/tasks/install_selinux_tools.yml
@@ -1,22 +1,16 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __cockpit_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __cockpit_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Install SELinux python2 tools
   package:
@@ -24,6 +18,8 @@
       - libselinux-python
       - policycoreutils-python
     state: present
+    use: "{{ (__cockpit_is_ostree | d(false)) |
+      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - ansible_python_version is version('3', '<')
     - ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"]
@@ -34,6 +30,8 @@
       - python3-libselinux
       - python3-policycoreutils
     state: present
+    use: "{{ (__cockpit_is_ostree | d(false)) |
+      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - ansible_python_version is version('3', '>=')
     - ansible_distribution in ["Fedora", "CentOS", "RedHat", "Rocky"]
@@ -43,6 +41,8 @@
     name:
       - policycoreutils-python-utils
     state: present
+    use: "{{ (__cockpit_is_ostree | d(false)) |
+      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: ansible_distribution == "Fedora" or
     (ansible_distribution_major_version | int > 7 and
      ansible_distribution in ["CentOS", "RedHat", "Rocky"])

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -47,7 +47,7 @@
             msg: cockpit is unexpectedly installed
           when:
             - "'cockpit' in ansible_facts.packages"
-            - ansible_facts.pkg_mgr | d() != "ansible.posix.rhel_rpm_ostree"
+            - not __cockpit_is_ostree | d(false)
 
         - name: Test - write expected configuration file
           copy:


### PR DESCRIPTION
The dependency on `ansible.utils.update_fact` is causing issue with
some users who now must install that collection in order to run
the role, even if they do not care about ostree.

The fix is to stop trying to set `ansible_facts.pkg_mgr`, and instead
force the use of the ostree package manager with the `package:` module
`use:` option.  The strategy is - on ostree systems, set the flag
`__$ROLENAME_is_ostree` if the system is an ostree system.  The flag
will either be undefined or `false` on non-ostree systems.
Then, change every invocation of the `package:` module like this:

```yaml
- name: Ensure required packages are present
  package:
    name: "{{ __$ROLENAME_packages }}"
    state: present
    use: "{{ (__$ROLENAME_is_ostree | d(false)) |
      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
```

This should ensure that the `use:` parameter is not used if the system
is non-ostree.  The goal is to make the ostree support as unobtrusive
as possible for non-ostree systems.
The user can also set `__$ROLENAME_is_ostree: true` in the inventory or play
if the user knows that ostree is being used and wants to skip the check.
Or, the user is concerned about the performance hit for ostree detection
on non-ostree systems, and sets `__$ROLENAME_is_ostree: false` to skip
the check.
The flag `__$ROLENAME_is_ostree` can also be used in the role or tests to
include or exclude tasks from being run on ostree systems.

This fix also improves error reporting in the `get_ostree_data.sh` script
when included roles cannot be found.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
