### PR TITLE
ci: Fix implicit octal values

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Create custom port configuration file
   copy:
     dest: /etc/systemd/system/cockpit.socket.d/listen.conf
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
     content: |
@@ -78,7 +78,7 @@
   template:
     src: templates/cockpit.conf.j2
     dest: /etc/cockpit/cockpit.conf
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
     backup: true

--- a/tests/tests_certificate_external.yml
+++ b/tests/tests_certificate_external.yml
@@ -28,7 +28,7 @@
                 path: /etc/cockpit/ws-certs.d/
                 state: directory
                 setype: cert_t
-                mode: 0755
+                mode: "0755"
 
             # has to be done dynamically, as the first step checks it out
             - name: Generate certificate with certificate system role

--- a/tests/tests_certificate_runafter.yml
+++ b/tests/tests_certificate_runafter.yml
@@ -21,7 +21,7 @@
         path: /etc/cockpit/ws-certs.d/
         state: directory
         setype: cert_t
-        mode: 0755
+        mode: "0755"
 
     # has to be done dynamically, as the first step checks it out
     - name: Generate certificate with certificate system role

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -64,7 +64,7 @@
               LoginTitle = hello world
 
             dest: /run/cockpit.conf.expected
-            mode: 0600
+            mode: "0600"
 
         - name: Test - compare generated with expected configuration file
           command: diff -u /run/cockpit.conf.expected /etc/cockpit/cockpit.conf

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -21,7 +21,7 @@
             dest: /run/out
             url: https://localhost:9090
             validate_certs: false
-            mode: 0600
+            mode: "0600"
 
         - name: Test - HTTP response is something sensible
           command: grep 'id="login-user-input"' /run/out

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -31,7 +31,7 @@
             dest: /run/out
             url: https://localhost
             validate_certs: false
-            mode: 0600
+            mode: "0600"
 
         - name: Test - HTTP response is something sensible
           command: grep 'id="login-user-input"' /run/out
@@ -42,7 +42,7 @@
             dest: /run/out
             url: https://localhost:9090
             validate_certs: false
-            mode: 0600
+            mode: "0600"
           register: result
           failed_when: result is succeeded
 

--- a/tests/tests_port2.yml
+++ b/tests/tests_port2.yml
@@ -23,7 +23,7 @@
             dest: /run/out
             url: https://localhost
             validate_certs: false
-            mode: 0600
+            mode: "0600"
 
         - name: Test - HTTP response is something sensible
           command: grep 'id="login-user-input"' /run/out
@@ -34,7 +34,7 @@
             dest: /run/out
             url: https://localhost:9090
             validate_certs: false
-            mode: 0600
+            mode: "0600"
           register: result
           failed_when: result is succeeded
 


### PR DESCRIPTION
Enhancement: Fix implicit octal values in main.yml

Reason: Forbidden implicit octal values "0644" were found on lines 50, 81, and additional occurrences.

Result: Updated to use explicit octal format for better readability and to adhere to linting standards.

Issue Tracker Tickets (Jira or BZ if any):na