### PR TITLE
ci: Use supported ansible-lint action; run ansible-lint against the collection

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 


### PR DESCRIPTION
Add `---` doc start to .markdownlint.yaml

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
