### PR TITLE
ci: Add ALP-Dolomite var file

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,4 +2,5 @@
 ---
 collections:
   - ansible.posix
+  - community.general
   - fedora.linux_system_roles

--- a/tasks/setup-zypper.yml
+++ b/tasks/setup-zypper.yml
@@ -1,0 +1,21 @@
+---
+- name: If choosing custom package set, ensure minimal cockpit is included
+  set_fact:
+    cockpit_packages: "{{ cockpit_packages + __cockpit_packages_minimal
+      if cockpit_packages not in __cockpit_package_types
+      else cockpit_packages }}"
+  when: cockpit_packages is defined
+
+- name: Ensure Cockpit Web Console packages are installed.
+  zypper:
+    name: "{{ __cockpit_packages[cockpit_packages]
+      if cockpit_packages in __cockpit_package_types
+      else cockpit_packages }}"
+    state: present
+
+- name: Reboot system
+  reboot:
+  when: ansible_distribution == 'ALP-Dolomite'
+
+- name: Flush handlers
+  meta: flush_handlers

--- a/tasks/setup-zypper.yml
+++ b/tasks/setup-zypper.yml
@@ -16,6 +16,3 @@
 - name: Reboot system
   reboot:
   when: ansible_distribution == 'ALP-Dolomite'
-
-- name: Flush handlers
-  meta: flush_handlers

--- a/tasks/setup-zypper.yml
+++ b/tasks/setup-zypper.yml
@@ -7,7 +7,7 @@
   when: cockpit_packages is defined
 
 - name: Ensure Cockpit Web Console packages are installed.
-  zypper:
+  community.general.zypper:
     name: "{{ __cockpit_packages[cockpit_packages]
       if cockpit_packages in __cockpit_package_types
       else cockpit_packages }}"

--- a/vars/ALP-Dolomite.yml
+++ b/vars/ALP-Dolomite.yml
@@ -1,0 +1,22 @@
+---
+__cockpit_packages_minimal:
+  - cockpit-system
+  - cockpit-ws
+__cockpit_packages_default:
+  - cockpit-bridge
+  - cockpit-networkmanager
+  - cockpit-selinux
+  - cockpit-storaged
+__cockpit_packages_full:
+  - cockpit-bridge
+  - cockpit-machines
+  - cockpit-networkmanager
+  - cockpit-podman
+  - cockpit-selinux
+  - cockpit-storaged
+  - cockpit-tukit
+__cockpit_packages:
+  minimal: "{{ __cockpit_packages_minimal }}"
+  default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
+  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
+    __cockpit_packages_full }}"


### PR DESCRIPTION
Enhancement: This pull request adds the `ALP-Dolomite.yml` variable file and setup-zypper.yml to support SUSE ALP-Dolomite configurations.

Reason: The existing configuration does not cover [SUSE ALP](https://documentation.suse.com/alp/dolomite/html/alp-dolomite/index.html).

Result: Works as expected in the added operating system.

Issue Tracker Tickets (Jira or BZ if any):na
