### PR TITLE
ci: Add check for Cockpit package installation status in reboot condition

### DIFF
--- a/tasks/setup-zypper.yml
+++ b/tasks/setup-zypper.yml
@@ -18,4 +18,4 @@
   reboot:
   when:
     - cockpit_installation_status is changed
-    - ansible_distribution == 'ALP-Dolomite'
+    - ansible_distribution == "ALP-Dolomite"

--- a/tasks/setup-zypper.yml
+++ b/tasks/setup-zypper.yml
@@ -12,7 +12,10 @@
       if cockpit_packages in __cockpit_package_types
       else cockpit_packages }}"
     state: present
+  register: cockpit_installation_status
 
-- name: Reboot system
+- name: Reboot transactional update systems
   reboot:
-  when: ansible_distribution == 'ALP-Dolomite'
+  when:
+    - cockpit_installation_status is changed
+    - ansible_distribution == 'ALP-Dolomite'


### PR DESCRIPTION
Enhancement: Add check for Cockpit package installation status in reboot condition

Reason: To prevent unnecessary reboots by adding a check for changes in Cockpit package installations. 

Result: System reboots will now only occur if there's a change in Cockpit package installation status

Issue Tracker Tickets (Jira or BZ if any): na
