### PR TITLE
test: Ensure cleanup and proper service state on ostree

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -12,6 +12,16 @@
     - always
     - tests::cleanup
 
+- name: Cleanup - services
+  service:
+    name: "{{ __cockpit_daemon }}"
+    state: stopped
+    enabled: false
+  when: __cockpit_is_ostree | d(false)
+  tags:
+    - always
+    - tests::cleanup
+
 - name: Cleanup - find certificates
   find:
     paths: /etc/cockpit/ws-certs.d/

--- a/tests/tests_certificate_existing.yml
+++ b/tests/tests_certificate_existing.yml
@@ -2,14 +2,16 @@
 # yamllint disable rule:line-length
 - name: Test using an existing certificate with cockpit
   hosts: all
-  roles:
-    - role: linux-system-roles.cockpit
+  tasks:
+    - name: Include role
+      include_role:
+        name: linux-system-roles.cockpit
+        public: true
       vars:
         cockpit_packages: minimal
         cockpit_cert: /etc/myserver.crt
         cockpit_private_key: /etc/myserver.key
 
-  tasks:
     - name: Collect installed package versions
       package_facts:
 
@@ -25,6 +27,14 @@
           command: openssl req -new -x509 -key /etc/myserver.key -subj '/CN=localhost' -out /etc/myserver.crt -days 365
           args:
             creates: /etc/myserver.crt
+
+        # ostree cannot remove packages and cannot cleanup properly
+        # this works around that issue
+        - name: Restart cockpit to use the new certificates
+          service:
+            name: "{{ __cockpit_daemon }}"
+            state: restarted
+          when: __cockpit_is_ostree | d(false)
 
         - name: Test - cockpit works with TLS and expected certificate
           # noqa command-instead-of-module

--- a/tests/tests_certificate_external.yml
+++ b/tests/tests_certificate_external.yml
@@ -1,20 +1,16 @@
 ---
-# yamllint disable rule:line-length
-# This approach relies on https://github.com/linux-system-roles/certificate/pull/97 and cockpit ≥ 211,
-# so it does not work on RHEL/CentOS 7. tests_certificate_runafter.yml covers an approach which
-# works everywhere, but has to use a `runafter` script.
-- name: Install cockpit
-  hosts: all
-  vars:
-    cockpit_packages: minimal
-  roles:
-    - linux-system-roles.cockpit
-
-- name: Generate self-signed certmonger certificate
+- name: Test with generated self-signed certmonger certificate
   hosts: all
   tasks:
     - name: Tests
       block:
+        - name: Include role
+          include_role:
+            name: linux-system-roles.cockpit
+            public: true
+          vars:
+            cockpit_packages: minimal
+
         - name: Collect installed package versions
           package_facts:
 
@@ -40,6 +36,14 @@
                     dns: ['localhost', 'www.example.com']
                     ca: self-sign
                     group: cockpit-ws
+
+            # ostree cannot remove packages and cannot cleanup properly
+            # this works around that issue
+            - name: Restart cockpit to use the new certificates
+              service:
+                name: "{{ __cockpit_daemon }}"
+                state: restarted
+              when: __cockpit_is_ostree | d(false)
 
             #
             # Validate installation

--- a/tests/tests_certificate_internal.yml
+++ b/tests/tests_certificate_internal.yml
@@ -19,6 +19,7 @@
                     group: cockpit-ws
               include_role:
                 name: linux-system-roles.cockpit
+                public: true
           rescue:
             - name: Check the error message
               vars:
@@ -41,6 +42,14 @@
           block:
             - name: Collect installed package versions
               package_facts:
+
+            # ostree cannot remove packages and cannot cleanup properly
+            # this works around that issue
+            - name: Restart cockpit to use the new certificates
+              service:
+                name: "{{ __cockpit_daemon }}"
+                state: restarted
+              when: __cockpit_is_ostree | d(false)
 
             # Validate installation
             - name: Test - cockpit works with TLS and expected certificate

--- a/tests/tests_certificate_runafter.yml
+++ b/tests/tests_certificate_runafter.yml
@@ -11,6 +11,7 @@
         cockpit_packages: minimal
       include_role:
         name: linux-system-roles.cockpit
+        public: true
 
     # self-signed is broken (https://github.com/linux-system-roles/certificate/issues/98),
     # and has too restrictive keyUsage so that using the certificate as CA is not allowed
@@ -47,6 +48,14 @@
 
     - name: Validate installation
       block:
+        # ostree cannot remove packages and cannot cleanup properly
+        # this works around that issue
+        - name: Restart cockpit to use the new certificates
+          service:
+            name: "{{ __cockpit_daemon }}"
+            state: restarted
+          when: __cockpit_is_ostree | d(false)
+
         # ugh, is there really no better way to do that?
         - name: Get PEM of certmonger's local CA
           command:

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -19,6 +19,7 @@
         - name: Run cockpit role
           include_role:
             name: linux-system-roles.cockpit
+            public: true
           vars:
             cockpit_packages: minimal
             cockpit_port: 443


### PR DESCRIPTION
non-ostree system cleanup will remove the packages, which has
side effects such as stopping and removing services.  Cannot remove
packages on ostree system, so try to do something similar.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
