### PR TITLE
fix: wildcard package installation not working with dnf module

### DIFF
--- a/tasks/setup-dnf.yml
+++ b/tasks/setup-dnf.yml
@@ -13,3 +13,18 @@
               else cockpit_packages }}"
     exclude: "{{ __cockpit_packages_exclude }}"
     state: present
+
+# using the dnf module to install cockpit-* is not working in
+# newer el9
+- name: Ensure full package list is installed
+  command:
+    argv: "{{ __argv }}"
+  when: "'cockpit-*' in __pkgs"
+  register: __cockpit_dnf
+  changed_when: "'Nothing to do.' not in __cockpit_dnf.stdout_lines"
+  vars:
+    __excludes: "{{ ['--exclude'] | product(__cockpit_packages_exclude) | flatten }}"
+    __argv: "{{ ['dnf', '-y', 'install', 'cockpit-*'] + __excludes }}"
+    __pkgs: "{{ __cockpit_packages[cockpit_packages]
+      if cockpit_packages in __cockpit_package_types
+      else cockpit_packages }}"

--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -43,6 +43,12 @@
             msg: cockpit-doc is not installed
           when: "'cockpit-doc' not in ansible_facts.packages"
 
+        - name: Ensure excluded packages are not installed
+          fail:
+            msg: The package {{ item }} should not be installed
+          when: item in ansible_facts.packages
+          loop: "{{ __cockpit_packages_exclude | d([]) }}"
+
         - name: >-
             Test - ensure cockpit_port is configured for firewall and selinux
           include_tasks: tasks/check_port.yml


### PR DESCRIPTION
Cause: The dnf module is not installing cockpit-*

Consequence: The full list of requested packages is not installed.

Fix: Call the dnf command directly with the wildcard package name
and the packages to exclude.

Result: The requested wildcard packages are installed.