### PR TITLE
fix: add support for EL10

### DIFF
--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,0 +1,1 @@
+cockpit-*

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,0 +1,1 @@
+cockpit-*

--- a/.ostree/packages-testing-RedHat-10.txt
+++ b/.ostree/packages-testing-RedHat-10.txt
@@ -1,0 +1,3 @@
+libselinux-python3
+policycoreutils-python3
+policycoreutils-python-utils

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,9 +15,13 @@ galaxy_info:
         - "8"
         - "9"
   galaxy_tags:
-    - rhel
-    - redhat
-    - fedora
     - centos
     - cockpit
+    - el7
+    - el8
+    - el9
+    - el10
+    - fedora
+    - redhat
+    - rhel
 dependencies: []

--- a/vars/CentOS-10.yml
+++ b/vars/CentOS-10.yml
@@ -1,0 +1,34 @@
+---
+# RHEL Web Console (Cockpit) only:#
+#  to validate this list of packages for each Major.Minor release
+#
+# for MINOR in 0 1; do
+#   subscription-manager release --set="9.${MINOR}"
+#   yum clean all
+#   yum repoquery cockpit* --disablerepo=* \
+#     --enablerepo=rhel-9-for-x86_64-appstream-rpms \
+#     --enablerepo=rhel-9-for-x86_64-baseos-rpms \
+#     --queryformat '%{name}.%{arch} : %{reponame}' ;
+# done;
+#
+__cockpit_packages_minimal:
+  - cockpit-system
+  - cockpit-ws
+__cockpit_packages_default:
+  - cockpit
+  - cockpit-networkmanager
+  - cockpit-packagekit
+  - cockpit-selinux
+  - cockpit-storaged
+__cockpit_packages_full:
+  - cockpit-*
+__cockpit_packages:
+  minimal: "{{ __cockpit_packages_minimal }}"
+  default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
+  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
+    __cockpit_packages_full }}"
+__cockpit_packages_exclude:
+  - cockpit-docker   # omit in favor of podman
+  - cockpit-ostree   # omit only needed for CoreOS
+  - cockpit-tests    # omit only needed for testing
+# --------------------------

--- a/vars/RedHat-10.yml
+++ b/vars/RedHat-10.yml
@@ -1,0 +1,34 @@
+---
+# RHEL Web Console (Cockpit) only:#
+#  to validate this list of packages for each Major.Minor release
+#
+# for MINOR in 0 1; do
+#   subscription-manager release --set="9.${MINOR}"
+#   yum clean all
+#   yum repoquery cockpit* --disablerepo=* \
+#     --enablerepo=rhel-9-for-x86_64-appstream-rpms \
+#     --enablerepo=rhel-9-for-x86_64-baseos-rpms \
+#     --queryformat '%{name}.%{arch} : %{reponame}' ;
+# done;
+#
+__cockpit_packages_minimal:
+  - cockpit-system
+  - cockpit-ws
+__cockpit_packages_default:
+  - cockpit
+  - cockpit-networkmanager
+  - cockpit-packagekit
+  - cockpit-selinux
+  - cockpit-storaged
+__cockpit_packages_full:
+  - cockpit-*
+__cockpit_packages:
+  minimal: "{{ __cockpit_packages_minimal }}"
+  default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
+  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
+    __cockpit_packages_full }}"
+__cockpit_packages_exclude:
+  - cockpit-docker   # omit in favor of podman
+  - cockpit-ostree   # omit only needed for CoreOS
+  - cockpit-tests    # omit only needed for testing
+# --------------------------


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
