### PR TITLE
ci: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ is `RedHat`.
 
 See also the [Cockpit guide](https://cockpit-project.org/guide/latest/listen.html#listen-systemd) for details.
 
+### cockpit_transactional_update_reboot_ok
+
+```yaml
+cockpit_transactional_update_reboot_ok: true
+```
+
+This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if cockpit_transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.
+
 ## Certificate setup
 
 By default, Cockpit creates a self-signed certificate for itself on first startup. This should [be customized](https://cockpit-project.org/guide/latest/https.html) for environments which use real certificates.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,6 @@ cockpit_manage_selinux: false
 
 # pass to the certificate_requests variable of the certificate role.
 cockpit_certificates: []
+
+# var to manage reboots for transactional update systems
+cockpit_transactional_update_reboot_ok: null

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -11,4 +11,4 @@
                   [{'port': _cockpit_port_proto, 'state': 'enabled'}] }}"
   when:
     - cockpit_manage_firewall | bool
-    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Suse'

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -9,5 +9,5 @@
                          'state': 'present', 'local': 'true'}] }}"
   when:
     - cockpit_manage_selinux | bool
-    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Suse'
     - cockpit_port is not none

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -17,6 +17,18 @@
       set_fact:
         __cockpit_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __cockpit_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __cockpit_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Set version specific variables
   include_vars: "{{ item }}"
   with_first_found:

--- a/tasks/setup-zypper.yml
+++ b/tasks/setup-zypper.yml
@@ -12,3 +12,26 @@
       if cockpit_packages in __cockpit_package_types
       else cockpit_packages }}"
     state: present
+  register: cockpit_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __cockpit_is_transactional | d(false)
+    - cockpit_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: cockpit_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set 'cockpit_transactional_update_reboot_ok' to proceed.
+      when:
+        - cockpit_transactional_update_reboot_ok is none

--- a/vars/SL-Micro.yml
+++ b/vars/SL-Micro.yml
@@ -9,7 +9,6 @@ __cockpit_packages_default:
   - cockpit-storaged
 __cockpit_packages_full:
   - cockpit-bridge
-  - cockpit-machines
   - cockpit-networkmanager
   - cockpit-podman
   - cockpit-selinux


### PR DESCRIPTION
Enhancement: - Added a block to identify and handle reboots for transactional update systems on package changes. Update README. Rename ALP-Dolomite var file to SL-Micro as the name is no longer used.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
