### PR TITLE
test: skip check for excluded packages on ostree

### DIFF
--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -46,7 +46,9 @@
         - name: Ensure excluded packages are not installed
           fail:
             msg: The package {{ item }} should not be installed
-          when: item in ansible_facts.packages
+          when:
+            - not __cockpit_is_ostree | d(false)  # skip this test on ostree
+            - item in ansible_facts.packages
           loop: "{{ __cockpit_packages_exclude | d([]) }}"
 
         - name: >-


### PR DESCRIPTION
Skip the check for missing excluded packages on ostree.  The packages
are built-in to the image - no easy way to build image with these
packages excluded.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
