### PR TITLE
test: cockpit-pcp is deprecated - use cockpit-machines

### DIFF
--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -32,10 +32,10 @@
           when: "'cockpit' not in ansible_facts.packages"
 
         # extra package (part of full)
-        - name: Test - cockpit-pcp is installed
+        - name: Test - cockpit-machines package is installed
           fail:
-            msg: cockpit-pcp is not installed
-          when: "'cockpit-pcp' not in ansible_facts.packages"
+            msg: cockpit-machines is not installed
+          when: "'cockpit-machines' not in ansible_facts.packages"
 
         # another extra package (part of full)
         - name: Test - cockpit-doc is installed


### PR DESCRIPTION
The tests_packages_full test is failing on el9.6 and later - cockpit-pcp
is missing - use cockpit-machines instead which seems to be available
on all platforms.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
