### PR TITLE
test: Drop cockpit-ws* groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ assuming your machines are joined to a FreeIPA domain.
           - name: monger-cockpit
             dns: ['localhost', 'www.example.com']
             ca: ipa
-            group: cockpit-ws
+            # with Cockpit < 257 (RHEL 7) you need:
+            # group: cockpit-ws
 ```
 
 Note: Generating a new certificate using the `certificate` system role in the playbook remains supported.
@@ -235,7 +236,8 @@ This example also installs Cockpit with an IdM-issued web server certificate.
           - name: /etc/cockpit/ws-certs.d/monger-cockpit
             dns: ['localhost', 'www.example.com']
             ca: ipa
-            group: cockpit-ws  # or cockpit-wsinstance on newer cockpit versions
+            # with Cockpit < 257 (RHEL 7) you need:
+            # group: cockpit-ws
 ```
 
 NOTE: The `certificate` role, unless using IPA and joining the systems to an IPA domain,

--- a/tests/tasks/get_cockpit_group.yml
+++ b/tests/tasks/get_cockpit_group.yml
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Get name of cockpit group for tests
-  getent:
-    database: group
-    key: cockpit-wsinstance
-    fail_key: false
 
+# The ownership of the certificate hasn't mattered since Cockpit 257,
+# which is in RHEL 8.7, 9.0, and all current Fedora/Debian/Ubuntu OSes.
+# This only matters for RHEL 7
 - name: Set __cockpit_test_group
   set_fact:
-    __cockpit_test_group: "{{ 'cockpit-wsinstance'
-      if ansible_facts['getent_group'].get('cockpit-wsinstance')
-      else 'cockpit-ws' }}"
+    __cockpit_test_group: "{{ 'cockpit-ws'
+      if (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_version'] | int == 7)
+      else 'root' }}"


### PR DESCRIPTION
Cockpit 330 (RHEL 9.6/10.0/Fedora 40) does not have any static system groups any more, everything is handled through `DynamicUser=`.

The ownership of the certificate hasn't mattered since Cockpit 257 [1], which is in RHEL 8.7, 9.0, and all current Fedora/Debian/Ubuntu OSes.

Setting a certificate group *can* be useful to share it with other services (like symlinking a global LetsEncrypt cert to ws-certs.d/), but this isn't what our documentation and tests do -- they produce a certificate exclusively for Cockpit. 

Adjust the documentation and get_cockpit_group.yml to special-case the "cockpit-ws" group ownership for RHEL 7, similar to what other tests already do. Note that there was *never* any situation where the certificate needs to be owned by `cockpit-wsinstance` -- this was always meant to be an internal implementation detail.

[1] https://github.com/cockpit-project/cockpit/commit/644116a0cd

----

This fixes the recent F41/C10 failures in #129. Draft because there are two issues to discuss:

 - [x] I didn't update .README.html -- this looks autogenerated. How do I update it? -- @spetrosi : autogenerated on release

 - [x] This won't work on RHEL/CentOS 7 (the test passes, but it doesn't check that cockpit's web server can *actually* read the cert). [CentOS 7 is dead](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol), so I propose to just drop that from CI. Do you still actually support RHEL 7 from main? If so, both README and the tests need to put back a conditional "if .el7 then group: cockpit-ws". Happy to do it, but is it actually worth it?