### PR TITLE
ci: Run QEMU tox integration tests in GitHub workflow

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -1,0 +1,85 @@
+---
+name: QEMU/KVM Integration tests
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+env:
+  TOX_ENV: qemu-ansible-core-2.16
+
+permissions:
+  contents: read
+jobs:
+  tox:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - centos-9
+          - centos-10
+          # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
+          # - fedora-41
+          - fedora-42
+
+    steps:
+      - name: Set up /dev/kvm
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm --settle
+          ls -l /dev/kvm
+
+      - name: Disable man-db to speed up package install
+        run: |
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
+      - name: Install test dependencies
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip
+          sudo apt update
+          sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Configure tox-lsr
+        run: |
+          curl -o ~/.config/linux-system-roles.json https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
+
+      - name: Run tox integration tests
+        run: tox -e ${{ env.TOX_ENV }} -- --image-name ${{ matrix.image }} --make-batch --log-level=debug --
+
+      - name: Test result summary
+        if: always()
+        run: |
+          set -euo pipefail
+          while read code start end f; do
+              if [ "$code" = "0" ]; then
+                  echo -n "PASS: "
+              else
+                  echo -n "FAIL: "
+              fi
+              echo "$(basename $f)"
+          done < batch.report
+
+      - name: Show test logs on failure
+        if: failure()
+        run: |
+          set -euo pipefail
+          for f in tests/*.log; do
+              echo "::group::$(basename $f)"
+              cat "$f"
+              echo "::endgroup::"
+          done


### PR DESCRIPTION
GitHub workflows recently grew the ability to set up nested QEMU kvm, but without much fanfare (see [1]). It just needs to create the `/dev/kvm` device node, but the host has it enabled and the kernel supports it.

With that we can run the QEMU tox tests. They are not covered anywhere else, and currently have some bugs, so let's cover them in CI and keep them green.

[1] https://github.com/orgs/community/discussions/8305

----

This is the same as https://github.com/linux-system-roles/sudo/pull/46 against the cockpit repo. This is mostly a test/proof that the workflow generalizes to more than just one role, and also a check for further OS image specific bugs. I also hope that the workflows start right away here, as I'm not a first-time contributor for this project :grin: 

 - [x] Builds on top of #201 