### PR TITLE
test: Remove all cockpit packages in cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+artifacts/
 passes.yml
 vault.yml
 *.retry

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -1,11 +1,7 @@
 ---
 - name: Cleanup - packages
   package:
-    name:
-      # everything else depends on one of these two, so will be removed along
-      - cockpit-bridge
-      - cockpit-ws
-      - cockpit-doc
+    name: "cockpit*"
     state: absent
   when: not __cockpit_is_ostree | d(false)
   tags:


### PR DESCRIPTION
The "reverse dependencies will be removed along" assumption isn't true any more in Fedora ≥ 41, and it's also not explicitly documented [1]. Trying to remove cockpit-bridge now fails because the installed cockpit-system depends on it.
    
Use a glob to remove all cockpit packages instead.
    
[1] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html

----

No release note, this is test only.

Fixes the [Fedora 41 failure](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_cockpit-129_Fedora-41-2.17_20250329-123139/artifacts/) in #129 (periodic testing), and also Fedora 42 (see #200).