### PR TITLE
fix: Reset certificate facts between playbook runs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,11 @@
   when: cockpit_config is defined
   notify: Restart cockpit
 
+- name: Clean up certificate facts from previous runs
+  set_fact:
+    cockpit_cert: ""
+    cockpit_private_key: ""
+
 - name: Create certificates
   when:
     - cockpit_certificates | length > 0
@@ -119,8 +124,8 @@
     state: link
     force: true
   when:
-    - cockpit_cert is defined
-    - cockpit_private_key is defined
+    - cockpit_cert | length > 0
+    - cockpit_private_key | length > 0
 
 - name: Link to configured existing certificate key
   file:
@@ -129,5 +134,5 @@
     state: link
     force: true
   when:
-    - cockpit_cert is defined
-    - cockpit_private_key is defined
+    - cockpit_cert | length > 0
+    - cockpit_private_key | length > 0

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -1,19 +1,19 @@
 ---
-- name: Cleanup - packages
-  package:
-    name: "cockpit*"
-    state: absent
-  when: not __cockpit_is_ostree | d(false)
-  tags:
-    - always
-    - tests::cleanup
-
 - name: Cleanup - services
   service:
     name: "{{ __cockpit_daemon }}"
     state: stopped
     enabled: false
   when: __cockpit_is_ostree | d(false)
+  tags:
+    - always
+    - tests::cleanup
+
+- name: Cleanup - packages
+  package:
+    name: "cockpit*"
+    state: absent
+  when: not __cockpit_is_ostree | d(false)
   tags:
     - always
     - tests::cleanup


### PR DESCRIPTION
When running `tests_certificate_external.yml tests/tests_default.yml` tox tests, the first test left non-empty `cockpit_{cert,private_key}` facts in Ansible's brain. This broke the second run in tests_default.yml, as that then created symlinks to files which no longer exist (as the actual certificates get removed in tests/tasks/cleanup.yml), and thus the "cockpit works with TLS" step failed as cockpit.service kept failing.

There is no way to unset a fact (setting it to `${{ undef() }}` errors out), so set them to an empty value, and replace "is defined" with an "is nonempty" check.

---

This wasn't reported as a bug, and just [breaks tests](https://github.com/linux-system-roles/cockpit/actions/runs/14214256715/job/39827190914?pr=200#step:6:25079) when you run  `tox -e qemu-ansible-core-2.16 -- --image-name fedora-42 tests/tests_*.yml` (or other OS), in particular with `tests/tests_certificate_external.yml tests/tests_default.yml`.

This patch is incorporated into #200 to prove that it works, but let's land it separately as there are more test failures to grind through.