### PR TITLE
fix: Avoid installing package glob with dnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ cockpit_packages: minimal
     #  - cockpit-ws
 
 cockpit_packages: full
-    # equivalent to globbing all of them
-    #  - cockpit-*
+    # equivalent to repoquery for 'cockpit-*'
     # This is will pull in many packages such as
         #  - cockpit    ## Default list
         #  - cockpit-bridge

--- a/tasks/setup-dnf.yml
+++ b/tasks/setup-dnf.yml
@@ -6,25 +6,23 @@
                           else cockpit_packages }}"
   when: cockpit_packages is defined
 
-- name: Ensure Cockpit Web Console packages are installed.
+- name: Determine all Cockpit Web Console packages
+  when: cockpit_packages == "full"
+  changed_when: false
+  shell: |
+    set -euo pipefail
+    dnf repoquery --latest-limit=1 --queryformat '%{name}\n' | grep -E '^cockpit-'
+  register: __cockpit_packages_full
+
+- name: Ensure Cockpit Web Console packages are installed
   dnf:
-    name: "{{ __cockpit_packages[cockpit_packages]
-              if cockpit_packages in __cockpit_package_types
-              else cockpit_packages }}"
+    name: "{{ (__cockpit_packages_minimal +
+              __cockpit_packages_full.stdout_lines | difference(__cockpit_packages_exclude))
+              if cockpit_packages == 'full'
+              else
+                  __cockpit_packages[cockpit_packages]
+                  if cockpit_packages in __cockpit_package_types
+                  else cockpit_packages }}"
+    # FIXME: this does not belong here, as it filters out explicit user-specified package lists as well
     exclude: "{{ __cockpit_packages_exclude }}"
     state: present
-
-# using the dnf module to install cockpit-* is not working in
-# newer el9
-- name: Ensure full package list is installed
-  command:
-    argv: "{{ __argv }}"
-  when: "'cockpit-*' in __pkgs"
-  register: __cockpit_dnf
-  changed_when: "'Nothing to do.' not in __cockpit_dnf.stdout_lines"
-  vars:
-    __excludes: "{{ ['--exclude'] | product(__cockpit_packages_exclude) | flatten }}"
-    __argv: "{{ ['dnf', '-y', 'install', 'cockpit-*'] + __excludes }}"
-    __pkgs: "{{ __cockpit_packages[cockpit_packages]
-      if cockpit_packages in __cockpit_package_types
-      else cockpit_packages }}"

--- a/tasks/setup-dnf5.yml
+++ b/tasks/setup-dnf5.yml
@@ -1,0 +1,1 @@
+setup-dnf.yml

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -64,6 +64,13 @@
             - "'cockpit' in ansible_facts.packages"
             - not __cockpit_is_ostree | d(false)
 
+        - name: Test - cockpit-doc is not installed
+          fail:
+            msg: cockpit-doc is unexpectedly installed
+          when:
+            - "'cockpit-doc' in ansible_facts.packages"
+            - not __cockpit_is_ostree | d(false)
+
         - name: Test - write expected configuration file
           copy:
             content: |+

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -8,13 +8,10 @@ __cockpit_packages_default:
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-__cockpit_packages_full:
-  - cockpit-*
 __cockpit_packages:
   minimal: "{{ __cockpit_packages_minimal }}"
   default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
-  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
-    __cockpit_packages_full }}"
+  # "full" is computed dynamically in tasks/setup-dnf.yml
 __cockpit_packages_exclude:
   - cockpit-docker   # omit in favor of podman
   - cockpit-ostree   # omit only needed for CoreOS

--- a/vars/RedHat-10.yml
+++ b/vars/RedHat-10.yml
@@ -20,13 +20,10 @@ __cockpit_packages_default:
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-__cockpit_packages_full:
-  - cockpit-*
 __cockpit_packages:
   minimal: "{{ __cockpit_packages_minimal }}"
   default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
-  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
-    __cockpit_packages_full }}"
+  # "full" is computed dynamically in tasks/setup-dnf.yml
 __cockpit_packages_exclude:
   - cockpit-docker   # omit in favor of podman
   - cockpit-ostree   # omit only needed for CoreOS

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -20,13 +20,10 @@ __cockpit_packages_default:
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-__cockpit_packages_full:
-  - cockpit-*
 __cockpit_packages:
   minimal: "{{ __cockpit_packages_minimal }}"
   default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
-  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
-    __cockpit_packages_full }}"
+  # "full" is computed dynamically in tasks/setup-dnf.yml
 __cockpit_packages_exclude:
   - cockpit-docker   # omit in favor of podman
   - cockpit-ostree   # omit only needed for CoreOS

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -20,13 +20,10 @@ __cockpit_packages_default:
   - cockpit-packagekit
   - cockpit-selinux
   - cockpit-storaged
-__cockpit_packages_full:
-  - cockpit-*
 __cockpit_packages:
   minimal: "{{ __cockpit_packages_minimal }}"
   default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
-  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default +
-    __cockpit_packages_full }}"
+  # "full" is computed dynamically in tasks/setup-dnf.yml
 __cockpit_packages_exclude:
   - cockpit-docker   # omit in favor of podman
   - cockpit-ostree   # omit only needed for CoreOS


### PR DESCRIPTION
Cause: Installing "cockpit-*" with dnf does not work on at least CentOS 9, and possibly other distributions. When multiple versions or architectures are available, `dnf install cockpit*` will try to install them all, which cannot work. (https://issues.redhat.com/browse/RHEL-85848)

Consequence: Playbook fails on package conflicts when configured with
`cockpit_packages: full`

Fix: Compute `__cockpit_packages_full` dynamically with `dnf repoquery` and only take package names into account, not their EVAR. 

Result: `cockpit_packages: full` now works in all cases.

Add an extra check to tests_config.yml that cockpit-doc (i.e. from the "full" set) is not installed.

Add a "FIXME" comment to how we handle `__cockpit_packages_exclude`: this should only apply to `cockpit_packages: full`, not to an actual package list specified by the user. But this is an unrelated change which I will do in a follow-up PR.

This does not affect yum or apt, as RedHat-7.yml and Debian.yml don't use globbing.

----

This fixes the [test_packages_full failure](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_cockpit-129_CentOS-Stream-9-2.17_20250329-123141/artifacts/tests_packages_full-ANSIBLE-2.17-test_playbooks_parallel-FAIL.log) which has plagued the Centos-9-Stream test for a while, see #129 and the [debugging notes](https://github.com/linux-system-roles/cockpit/pull/129#issuecomment-2772737884). This is also incorporated into #200 to make sure it works in tox as well.