### PR TITLE
fix: Ignore cockpit-pcp on RedHat 9

### DIFF
--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -31,4 +31,5 @@ __cockpit_packages_exclude:
   - cockpit-docker   # omit in favor of podman
   - cockpit-ostree   # omit only needed for CoreOS
   - cockpit-tests    # omit only needed for testing
+  - cockpit-pcp      # not present any more in current composes, but in older ones, and conflicts with current bridge
 # --------------------------


### PR DESCRIPTION
Cause: Installing all "cockpit-*" packages with dnf does not work on at least CentOS 9: that publishes multiple versions of cockpit, in particular an old one where cockpit-pcp was still a separate package. Since version 326 [1] it was merged into cockpit-bridge.

Consequence: Playbook fails on package conflicts when configured with
`cockpit_packages: full` on CentOS 9.

Fix: Ignore the cockpit-pcp package on RHEL 9.

Result: `cockpit_packages: full` works again in all cases.

[1] https://github.com/cockpit-project/cockpit/releases/tag/326

----

This fixes the [test_packages_full failure](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_cockpit-129_CentOS-Stream-9-2.17_20250329-123141/artifacts/tests_packages_full-ANSIBLE-2.17-test_playbooks_parallel-FAIL.log) which has plagued the Centos-9-Stream test for a while, see #129 and the [debugging notes](https://github.com/linux-system-roles/cockpit/pull/129#issuecomment-2772737884). 

Reported to https://issues.redhat.com/browse/CS-2799