### PR TITLE
fix: Run Fedora 42 with dnf instead of default setup

### DIFF
--- a/tasks/setup-dnf5.yml
+++ b/tasks/setup-dnf5.yml
@@ -1,0 +1,1 @@
+setup-dnf.yml


### PR DESCRIPTION
`ansible_pkg_mgr` is `dnf5` on Fedora 42.

----

This was some side-issue which I originally needed for #203. That is obsolete now, but and this change currently doesn't have an observable effect -- but it's still a trap in the future, so let's fix it.