### PR TITLE
fix: Dynamically ignore cockpit-pcp

### DIFF
--- a/tasks/setup-dnf.yml
+++ b/tasks/setup-dnf.yml
@@ -6,12 +6,29 @@
                           else cockpit_packages }}"
   when: cockpit_packages is defined
 
-- name: Ensure Cockpit Web Console packages are installed.
+- name: Get cockpit-bridge available version in "full" package install mode
+  when: cockpit_packages == "full"
+  changed_when: false
+  command: dnf repoquery --latest-limit=1 --queryformat '%{version}' cockpit-bridge
+  register: __cockpit_bridge_version
+
+# cockpit-pcp was merged into cockpit-bridge in version 326, and thus
+# and conflicts with current bridge; but CentOS 9 composes have older versions
+# published, this leads to installation conflicts
+# https://issues.redhat.com/browse/CS-2799
+- name: Ignore cockpit-pcp in "full" package install mode with Cockpit ≥ 326
+  set_fact:
+    cockpit_packages_dyn_exclude: "{{ ['cockpit-pcp']
+      if cockpit_packages == 'full'
+      and __cockpit_bridge_version.stdout is version('326', '>=')
+      else [] }}"
+
+- name: Ensure Cockpit Web Console packages are installed
   dnf:
     name: "{{ __cockpit_packages[cockpit_packages]
               if cockpit_packages in __cockpit_package_types
               else cockpit_packages }}"
-    exclude: "{{ __cockpit_packages_exclude }}"
+    exclude: "{{ __cockpit_packages_exclude | union(cockpit_packages_dyn_exclude) }}"
     state: present
 
 # using the dnf module to install cockpit-* is not working in
@@ -23,7 +40,7 @@
   register: __cockpit_dnf
   changed_when: "'Nothing to do.' not in __cockpit_dnf.stdout_lines"
   vars:
-    __excludes: "{{ ['--exclude'] | product(__cockpit_packages_exclude) | flatten }}"
+    __excludes: "{{ ['--exclude'] | product(__cockpit_packages_exclude | union(cockpit_packages_dyn_exclude)) | flatten }}"
     __argv: "{{ ['dnf', '-y', 'install', 'cockpit-*'] + __excludes }}"
     __pkgs: "{{ __cockpit_packages[cockpit_packages]
       if cockpit_packages in __cockpit_package_types

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -31,5 +31,4 @@ __cockpit_packages_exclude:
   - cockpit-docker   # omit in favor of podman
   - cockpit-ostree   # omit only needed for CoreOS
   - cockpit-tests    # omit only needed for testing
-  - cockpit-pcp      # not present any more in current composes, but in older ones, and conflicts with current bridge
 # --------------------------


### PR DESCRIPTION
Commit 61ff76416c37036de67 statically ignored cockpit-pcp. But that changes the role behaviour on earlier RHEL 9.y versions with Cockpit < 326.

So revert the original change, and instead determine whether to ignore cockpit-pcp dynamically, by doing a version comparison on the available cockpit-bridge version.

----

Follow-up for https://github.com/linux-system-roles/cockpit/pull/204#discussion_r2028890046 . This still works on CentOS 9 (covered by integration tests). I also ran this against the "rhel-9-4" image (from internal config) and it behaves as expected, i.e. installs pcp:

```
TASK [linux-system-roles.cockpit : Get cockpit-bridge available version in "full" package install mode] ********************************
task path: /var/home/martin/upstream/lsr/cockpit/tests/roles/linux-system-roles.cockpit/tasks/setup-dnf.yml:9
[...]
STDOUT:
311.1

[...]
TASK [linux-system-roles.cockpit : Ignore cockpit-pcp in "full" package install mode with Cockpit ≥ 326] *******************************
task path: /var/home/martin/upstream/lsr/cockpit/tests/roles/linux-system-roles.cockpit/tasks/setup-dnf.yml:23
Monday 07 April 2025  10:09:26 +0200 (0:00:00.014)       0:00:13.371 ********** 
skipping: [/var/home/martin/.cache/linux-system-roles/rhel-9-4.qcow2] => {
    "changed": false,
    "false_condition": "__cockpit_bridge_version.stdout is version('326', '>=')",
    "skip_reason": "Conditional result was False"
}
```

and in ssh you see the -pcp package was installed:

```
# rpm -qa 'cockpit*'|sort
cockpit-311.1-1.el9.x86_64
cockpit-bridge-311.1-1.el9.x86_64
cockpit-composer-50-1.el9.noarch
cockpit-doc-311.1-1.el9.noarch
cockpit-machines-308-1.el9.noarch
cockpit-packagekit-311.1-1.el9.noarch
cockpit-pcp-311.1-1.el9.x86_64
cockpit-podman-84.1-1.el9.noarch
cockpit-session-recording-16-1.el9.noarch
cockpit-storaged-311.1-1.el9.noarch
cockpit-system-311.1-1.el9.noarch
cockpit-ws-311.1-1.el9.x86_64
```