### PR TITLE
ci: Remove EOL ubuntu-20.04 runner, add 24.04

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         release:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     runs-on: '${{ matrix.release }}'
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
The "ubuntu-20.04" runner will be switched off in a week, and is currently browning out.

See https://github.com/actions/runner-images/issues/11101.

---

See the annotation in e.g. https://github.com/linux-system-roles/tox-lsr/actions/runs/14334537098/job/40179317006?pr=181
