### PR TITLE
feat: Support this role in container builds

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: QEMU/KVM Integration tests
+name: Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
   merge_group:
@@ -17,18 +17,34 @@ permissions:
   # This is required for the ability to create/update the Pull request status
   statuses: write
 jobs:
-  qemu_kvm:
+  scenario:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scenario:
+          # QEMU
           - { image: "centos-9", env: "qemu-ansible-core-2.16" }
           - { image: "centos-10", env: "qemu-ansible-core-2.17" }
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
           # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2.17" }
+
+          # container
+          - { image: "centos-9", env: "container-ansible-core-2.16" }
+          - { image: "centos-9-bootc", env: "container-ansible-core-2.16" }
+          # broken on non-running dbus
+          # - { image: "centos-10", env: "container-ansible-core-2.17" }
+          - { image: "centos-10-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+
+    env:
+      TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -38,6 +54,7 @@ jobs:
         run: |
           set -euxo pipefail
           image="${{ matrix.scenario.image }}"
+          image="${image%-bootc}"
 
           # convert image to tag formats
           platform=
@@ -49,6 +66,20 @@ jobs:
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then
             supported=true
+          fi
+
+          # bootc build support (in buildah) has a separate flag
+          if [ "${{ matrix.scenario.image }}" != "$image" ]; then
+            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+              supported=
+            fi
+          else
+            # roles need to opt into support for running in a system container
+            env="${{ matrix.scenario.env }}"
+            if [ "${env#container}" != "$env" ] &&
+              ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "container")' meta/main.yml; then
+              supported=
+            fi
           fi
 
           echo "supported=$supported" >> "$GITHUB_OUTPUT"
@@ -82,14 +113,13 @@ jobs:
           curl -o ~/.config/linux-system-roles.json
           https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
 
-      - name: Run qemu/kvm tox integration tests
-        if: steps.check_platform.outputs.supported
-        run: >-
-          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
+      - name: Run qemu integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
+        run: |
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch $TOX_ARGS --
 
-      - name: Test result summary
-        if: steps.check_platform.outputs.supported && always()
+      - name: Qemu result summary
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
         run: |
           set -euo pipefail
           # some platforms may have setup/cleanup playbooks - need to find the
@@ -108,6 +138,24 @@ jobs:
               fi
               echo "$f"
           done < batch.report
+
+      - name: Run container tox integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'container')
+        run: |
+          set -euo pipefail
+          # HACK: debug.py/profile.py setup is broken
+          export LSR_CONTAINER_PROFILE=false
+          export LSR_CONTAINER_PRETTY=false
+          rc=0
+          for t in tests/tests_*.yml; do
+              if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
+                  echo "$(basename $t): pass"
+              else
+                  echo "$(basename $t): FAIL"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Upload test logs on failure
         if: failure()
@@ -139,6 +187,6 @@ jobs:
         uses: myrotvorets/set-commit-status-action@master
         with:
           status: success
-          context: "${{ github.workflow }} / qemu_kvm (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+          context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
           description: The role does not support this platform. Skipping.
           targetUrl: ""

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,9 +3,11 @@
 - name: Reload systemd
   systemd:
     daemon_reload: true
+  when: __cockpit_is_booted
 
 - name: Restart cockpit
   service:
     name: "{{ __cockpit_daemon }}"
     # noqa args[module]
     state: "{{ 'restarted' if cockpit_started | bool else 'stopped' }}"
+  when: __cockpit_is_booted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,4 +24,5 @@ galaxy_info:
     - fedora
     - redhat
     - rhel
+    - containerbuild
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,11 +68,16 @@
     - Reload systemd
     - Restart cockpit
 
-- name: Ensure Cockpit Web Console is started/stopped and enabled/disabled
+- name: Ensure Cockpit Web Console is enabled/disabled
   service:
     name: "{{ __cockpit_daemon }}"
     enabled: "{{ cockpit_enabled | bool }}"
+
+- name: Ensure Cockpit Web Console is started/stopped
+  service:
+    name: "{{ __cockpit_daemon }}"
     state: "{{ 'started' if cockpit_started | bool else 'stopped' }}"
+  when: __cockpit_is_booted
 
 - name: Create cockpit.conf configuration file
   template:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,6 +5,21 @@
   when: __cockpit_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
+- name: Determine if system is booted with systemd
+  when: not __cockpit_is_booted is defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      failed_when: false
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __cockpit_is_booted: "{{ __is_system_running.stdout not in ['offline', 'degraded'] }}"
+
 - name: Determine if system is ostree and set flag
   when: not __cockpit_is_ostree is defined
   block:

--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -56,6 +56,7 @@
 - name: Cleanup - Reload systemd
   systemd:
     daemon_reload: true
+  when: __cockpit_is_booted
   tags:
     - always
     - tests::cleanup

--- a/tests/tests_certificate_existing.yml
+++ b/tests/tests_certificate_existing.yml
@@ -42,6 +42,7 @@
             cmd: curl --cacert /etc/myserver.crt https://localhost:9090
             # ansible 2.11's uri module has ca_path, but that's still too new for us
           changed_when: false
+          when: __cockpit_is_booted
 
       always:
         - name: Cleanup - test certificate cert

--- a/tests/tests_certificate_external.yml
+++ b/tests/tests_certificate_external.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test with generated self-signed certmonger certificate
   hosts: all
+  # certmonger does not work in container builds
+  tags:
+    - tests::booted
   tasks:
     - name: Tests
       block:

--- a/tests/tests_certificate_internal.yml
+++ b/tests/tests_certificate_internal.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test the cockpit role calling the certificate role internally
   hosts: all
+  # certmonger does not work in container builds
+  tags:
+    - tests::booted
   tasks:
     - name: Tests
       vars:

--- a/tests/tests_certificate_runafter.yml
+++ b/tests/tests_certificate_runafter.yml
@@ -5,6 +5,9 @@
 # yamllint disable rule:line-length
 - name: Test certificate issuance with run_after shell script
   hosts: all
+  # certmonger does not work in container builds
+  tags:
+    - tests::booted
   tasks:
     - name: Install cockpit
       vars:

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -48,6 +48,7 @@
           register: result
           failed_when: result is succeeded
           changed_when: false
+          when: __cockpit_is_booted
 
         - name: Refresh package facts
           package_facts:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -11,6 +11,7 @@
         - name: Test - socket is active  # noqa command-instead-of-module
           command: systemctl is-active {{ __cockpit_daemon }}
           changed_when: false
+          when: __cockpit_is_booted
 
         - name: Test - socket is enabled  # noqa command-instead-of-module
           command: systemctl is-enabled {{ __cockpit_daemon }}
@@ -22,10 +23,12 @@
             url: https://localhost:9090
             validate_certs: false
             mode: "0600"
+          when: __cockpit_is_booted
 
         - name: Test - HTTP response is something sensible
           command: grep 'id="login-user-input"' /run/out
           changed_when: false
+          when: __cockpit_is_booted
 
         - name: Test - clean up output file
           file:

--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -11,7 +11,8 @@
             public: true
           vars:
             cockpit_packages: full
-            cockpit_manage_firewall: true
+            # firewall role not yet supported during container builds: https://issues.redhat.com/browse/RHEL-88425
+            cockpit_manage_firewall: "{{ __cockpit_is_booted }}"
             cockpit_manage_selinux: false
 
         - name: Flush handlers

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -27,16 +27,23 @@
         - name: Flush handlers
           meta: flush_handlers
 
+        # config file only check for non-booted environments
+        - name: Test - Ensure that port was configured
+          command: grep -q ListenStream=443 /etc/systemd/system/cockpit.socket.d/listen.conf
+          changed_when: false
+
         - name: Test - cockpit works on customized port
           get_url:
             dest: /run/out
             url: https://localhost
             validate_certs: false
             mode: "0600"
+          when: __cockpit_is_booted
 
         - name: Test - HTTP response is something sensible
           command: grep 'id="login-user-input"' /run/out
           changed_when: false
+          when: __cockpit_is_booted
 
         - name: Test - cockpit does not listen on port 9090
           get_url:
@@ -46,6 +53,7 @@
             mode: "0600"
           register: result
           failed_when: result is succeeded
+          when: __cockpit_is_booted
 
         - name: Test - clean up output file
           file:

--- a/tests/tests_port2.yml
+++ b/tests/tests_port2.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test cockpit_* role options
   hosts: all
+  # firewall role does not yet work in container builds (https://issues.redhat.com/browse/RHEL-88425)
+  tags:
+    - tests::booted
   gather_facts: true
   tasks:
     - name: Tests
@@ -18,16 +21,23 @@
         - name: Flush handlers
           meta: flush_handlers
 
+        # config file only check for non-booted environments
+        - name: Test - Ensure that port was configured
+          command: grep -q ListenStream=443 /etc/systemd/system/cockpit.socket.d/listen.conf
+          changed_when: false
+
         - name: Test - cockpit works on customized port
           get_url:
             dest: /run/out
             url: https://localhost
             validate_certs: false
             mode: "0600"
+          when: __cockpit_is_booted
 
         - name: Test - HTTP response is something sensible
           command: grep 'id="login-user-input"' /run/out
           changed_when: false
+          when: __cockpit_is_booted
 
         - name: Test - cockpit does not listen on port 9090
           get_url:
@@ -37,6 +47,7 @@
             mode: "0600"
           register: result
           failed_when: result is succeeded
+          when: __cockpit_is_booted
 
         - name: Test - ensure cockpit_port is configured for firewall
           include_tasks: tasks/check_port.yml


### PR DESCRIPTION
Feature: Support running the cockpit role during container builds.
    
Reason: This is particularly useful for building bootc derivative OSes.
    
Result: These flags enable running the bootc container scenarios in CI, which ensures that the role works in buildah build environment. This allows us to officially support this role for image mode builds.
    
Do *not* enable the role for system containers (the `container`) flag. That currently fails due to SELinux not working properly there, and needs to be looked at separately if desired.

https://issues.redhat.com/browse/RHEL-88423


Skip the certmonger tests for non-booted environments, as certmonger requires a running system by design (these are a case for running the role in a deployed system). Also skip the firewall managed related checks for the time being, until the firewall role works during container builds (https://issues.redhat.com/browse/RHEL-88425).

 - [x] Review/land https://github.com/linux-system-roles/sudo/pull/52 as the initial PR for this machinery
 - [x] #213
 - [x] #214 
 - [x] adjust firewall rule for bootc tests