### PR TITLE
fix: Ignore extra lines in dnf repoquery parsing

### DIFF
--- a/tasks/setup-dnf.yml
+++ b/tasks/setup-dnf.yml
@@ -20,7 +20,7 @@
   set_fact:
     cockpit_packages_dyn_exclude: "{{ ['cockpit-pcp']
       if cockpit_packages == 'full'
-      and __cockpit_bridge_version.stdout is version('326', '>=')
+      and __cockpit_bridge_version.stdout_lines[-1] is version('326', '>=')
       else [] }}"
 
 - name: Ensure Cockpit Web Console packages are installed


### PR DESCRIPTION
Cause: In some RHEL environments, dnf operations write some extra output like "This system is not registered with an entitlement server."

Consequence: This breaks the `dnf repoquery` parsing introduced in commit d64b5603037f and makes the role fail due to the invalid value comparison.

Fix: Only consider the last line (which will be the actual version number).

---

This does not trigger in our current test environments as they don't have sub-man etc. installed. But it [did fail](https://github.com/linux-system-roles/cockpit/actions/runs/14637916143/job/41073261651#step:12:909) during bootc container test in #212. This is quite an urgent regression fix, so let's land it separately:

> TASK [linux-system-roles.cockpit : Get cockpit-bridge available version in "full" package install mode] ***
> ok: [sut] => {"changed": false, "cmd": ["dnf", "repoquery", "--latest-limit=1", "--queryformat", "%{version}", "cockpit-bridge"], "delta": "0:00:09.633826", "end": "2025-04-24 09:20:02.026645", "msg": "", "rc": 0, "start": "2025-04-24 09:19:52.392819", "stderr": "CentOS Stream 10 - BaseOS                       1.2 MB/s | 6.6 MB     00:05    \nCentOS Stream 10 - AppStream                    2.9 MB/s | 3.2 MB     00:01    \nCentOS Stream 10 - Extras packages               11 kB/s | 4.6 kB     00:00    ", "stderr_lines": ["CentOS Stream 10 - BaseOS                       1.2 MB/s | 6.6 MB     00:05    ", "CentOS Stream 10 - AppStream                    2.9 MB/s | 3.2 MB     00:01    ", "CentOS Stream 10 - Extras packages               11 kB/s | 4.6 kB     00:00    "], "stdout": "Updating Subscription Management repositories.\nUnable to read consumer identity\n\nThis system is not registered with an entitlement server. You can use subscription-manager to register.\n\n334.1", "stdout_lines": ["Updating Subscription Management repositories.", "Unable to read consumer identity", "", "This system is not registered with an entitlement server. You can use subscription-manager to register.", "", "334.1"]}

> TASK [linux-system-roles.cockpit : Ignore cockpit-pcp in "full" package install mode with Cockpit ≥ 326] ***
> fatal: [sut]: FAILED! => {"msg": "Version comparison failed: '<' not supported between instances of 'str' and 'int'"}