### PR TITLE
tests: Fix check_port.yml invocation, check permanent firewall configuration

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -6,9 +6,12 @@
   vars:
     _cockpit_port: "{{ cockpit_port if cockpit_port is not none else 9090 }}"
     _cockpit_port_proto: "{{ _cockpit_port }}/tcp"
-    firewall: "{{ [{'service': 'cockpit', 'state': 'enabled'}]
-                  if (_cockpit_port | int) == 9090 else
-                  [{'port': _cockpit_port_proto, 'state': 'enabled'}] }}"
+    firewall:
+        permanent: true
+        runtime: "{{ __cockpit_is_booted | bool }}"
+        state: enabled
+        service: "{{ 'cockpit' if (_cockpit_port | int) == 9090 else omit }}"
+        port: "{{ _cockpit_port_proto if (_cockpit_port | int) != 9090 else omit }}"
   when:
     - cockpit_manage_firewall | bool
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Suse'

--- a/tests/tasks/check_port.yml
+++ b/tests/tasks/check_port.yml
@@ -8,21 +8,40 @@
     - name: Check firewall port status
       when: cockpit_manage_firewall | bool
       block:
-        - name: Check firewall port status when cockpit_manage_firewall is yes
-          command: firewall-cmd --list-service
+        - name: Check permanent firewall port status when cockpit_manage_firewall is yes
+          command: firewall-offline-cmd --list-service
           register: _result
           failed_when: "'cockpit' not in _result.stdout"
           changed_when: false
           when:
             - _cockpit_port | int == 9090
 
+        - name: Check runtime firewall port status when cockpit_manage_firewall is yes
+          command: firewall-cmd --list-service
+          register: _result
+          failed_when: "'cockpit' not in _result.stdout"
+          changed_when: false
+          when:
+            - __cockpit_is_booted
+            - _cockpit_port | int == 9090
+
         - name: >-
-            Check firewall port status when cockpit_manage_firewall is yes
+            Check permanent firewall port status when cockpit_manage_firewall is yes
+          command: firewall-offline-cmd --list-port
+          register: _result
+          failed_when: "'{{ _cockpit_port }}/tcp' not in _result.stdout"
+          changed_when: false
+          when:
+            - _cockpit_port | int != 9090
+
+        - name: >-
+            Check runtime firewall port status when cockpit_manage_firewall is yes
           command: firewall-cmd --list-port
           register: _result
           failed_when: "'{{ _cockpit_port }}/tcp' not in _result.stdout"
           changed_when: false
           when:
+            - __cockpit_is_booted
             - _cockpit_port | int != 9090
 
     - name: Check SELinux port labeling

--- a/tests/tests_config.yml
+++ b/tests/tests_config.yml
@@ -2,6 +2,10 @@
 - name: Test cockpit_* role options
   hosts: all
   gather_facts: false
+  # role vars, but we also check them in tasks/check_port.yml
+  vars:
+    cockpit_manage_firewall: false
+    cockpit_manage_selinux: true
   roles:
     - role: linux-system-roles.cockpit
       vars:
@@ -13,8 +17,6 @@
             LoginTitle: "hello world"
           Session:
             IdleTimeout: 60
-        cockpit_manage_firewall: false
-        cockpit_manage_selinux: true
       public: true
 
   tasks:

--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -2,6 +2,10 @@
 - name: "Test cockpit_packages: full"
   hosts: all
   gather_facts: true
+  vars:
+    # firewall role not yet supported during container builds: https://issues.redhat.com/browse/RHEL-88425
+    cockpit_manage_firewall: "{{ __cockpit_is_booted }}"
+    cockpit_manage_selinux: false
   tasks:
     - name: Tests
       block:
@@ -11,9 +15,6 @@
             public: true
           vars:
             cockpit_packages: full
-            # firewall role not yet supported during container builds: https://issues.redhat.com/browse/RHEL-88425
-            cockpit_manage_firewall: "{{ __cockpit_is_booted }}"
-            cockpit_manage_selinux: false
 
         - name: Flush handlers
           meta: flush_handlers

--- a/tests/tests_port2.yml
+++ b/tests/tests_port2.yml
@@ -5,6 +5,11 @@
   tags:
     - tests::booted
   gather_facts: true
+  # role vars, but we also check them in tasks/check_port.yml
+  vars:
+    cockpit_manage_firewall: true
+    cockpit_manage_selinux: true
+    cockpit_port: 443
   tasks:
     - name: Tests
       block:
@@ -13,10 +18,7 @@
             name: linux-system-roles.cockpit
             public: true
           vars:
-            cockpit_manage_firewall: true
-            cockpit_manage_selinux: true
             cockpit_packages: minimal
-            cockpit_port: 443
 
         - name: Flush handlers
           meta: flush_handlers


### PR DESCRIPTION
While preparing cockpit role for bootc firewalld support, I noticed some accidentally skipped tests. Even for the ones which enabled selinux and firewall, check.port.yml always skipped:

```
TASK [Check persistent firewall port status when cockpit_manage_firewall is yes] *******************************************************
task path: /var/home/martin/upstream/lsr/cockpit/tests/tasks/check_port.yml:28
Wednesday 21 May 2025  09:26:28 +0200 (0:00:00.031)       0:00:27.151 ********* 
skipping: [/var/home/martin/.cache/linux-system-roles/centos-9.qcow2] => {
    "changed": false,
    "false_condition": "cockpit_manage_firewall | bool",
    "skip_reason": "Conditional result was False"
}

TASK [Check associated selinux ports when cockpit_manage_selinux is yes] ***************************************************************
task path: /var/home/martin/upstream/lsr/cockpit/tests/tasks/check_port.yml:53
Wednesday 21 May 2025  09:26:28 +0200 (0:00:00.031)       0:00:27.244 ********* 
skipping: [/var/home/martin/.cache/linux-system-roles/centos-9.qcow2] => {
    "changed": false,
    "false_condition": "cockpit_manage_selinux | bool",
    "skip_reason": "Conditional result was False"
}
```

Please review that carefully: Perhaps there is a more elegant fix for "tests: Fix check_port.yml invocation".

Also, I totally expected "check permanent firewall configuration" to fail, but it succeeded for me locally at least on CentOS 9. I still made the config explicit, more robust IMHO -- but I can't explain why it worked without `permanent: true`.

## Summary by Sourcery

Fix invocation and robustness of firewall port tests and explicit permanent firewall configuration

Enhancements:
- Split firewall port checks into permanent and runtime validations in check_port.yml
- Unify firewall role parameters to include explicit permanent and runtime flags and conditional service or port settings

Tests:
- Set cockpit_manage_firewall and cockpit_manage_selinux vars at the play level to ensure check_port tasks are executed
- Remove redundant variable declarations in test playbooks and adjust default port testing to avoid skipped tasks

Chores:
- Clean up test playbooks by relocating management vars outside of role definitions