### PR TITLE
tests: Enable firewall management tests in container builds

### DIFF
--- a/tests/tests_packages_full.yml
+++ b/tests/tests_packages_full.yml
@@ -3,8 +3,7 @@
   hosts: all
   gather_facts: true
   vars:
-    # firewall role not yet supported during container builds: https://issues.redhat.com/browse/RHEL-88425
-    cockpit_manage_firewall: "{{ __cockpit_is_booted }}"
+    cockpit_manage_firewall: true
     cockpit_manage_selinux: false
   tasks:
     - name: Tests

--- a/tests/tests_port2.yml
+++ b/tests/tests_port2.yml
@@ -1,9 +1,6 @@
 ---
 - name: Test cockpit_* role options
   hosts: all
-  # firewall role does not yet work in container builds (https://issues.redhat.com/browse/RHEL-88425)
-  tags:
-    - tests::booted
   gather_facts: true
   # role vars, but we also check them in tasks/check_port.yml
   vars:


### PR DESCRIPTION
The latest firewall role release now works in container builds: https://github.com/linux-system-roles/firewall/pull/274

Fixes https://issues.redhat.com/browse/RHEL-88423

## Summary by Sourcery

Enable firewall management tests in container builds by defaulting cockpit_manage_firewall to true and removing container build gating logic.

Tests:
- Remove conditional gating and tags to always run firewall management tests in container builds
- Set cockpit_manage_firewall to true in tests_packages_full.yml to enable firewall tests under containers