### PR TITLE
docs(changelog): version 1.6.1 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+[1.6.1] - 2025-06-16
+--------------------
+
+### Other Changes
+
+- tests: Fix check_port.yml invocation, check permanent firewall configuration (#219)
+- tests: Enable firewall management tests in container builds (#222)
+- tests: Update tests_port to do bootc end-to-end validation (#223)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#224)
+
 [1.6.0] - 2025-05-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.6.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Add changelog entry for version 1.6.1, update documentation, and adjust tests and CI to support new configurations

Bug Fixes:
- Fix invocation of check_port.yml in tests

Enhancements:
- Enable firewall management tests in container builds

CI:
- Use Ansible 2.19 for Fedora 42 testing and add Python 3.13 support

Documentation:
- Update CHANGELOG for version 1.6.1 and refresh README.html

Tests:
- Revise tests_port to perform bootc end-to-end validation