### PR TITLE
feat: add sles 16 support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,9 @@ galaxy_info:
         - "7"
         - "8"
         - "9"
+    - name: SLES
+      versions:
+        - "16"
   galaxy_tags:
     - centos
     - cockpit
@@ -25,4 +28,5 @@ galaxy_info:
     - redhat
     - rhel
     - containerbuild
+    - suse
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,9 +14,6 @@ galaxy_info:
         - "7"
         - "8"
         - "9"
-    - name: SLES
-      versions:
-        - "16"
   galaxy_tags:
     - centos
     - cockpit

--- a/vars/SLES-16.yml
+++ b/vars/SLES-16.yml
@@ -1,0 +1,27 @@
+---
+__cockpit_packages_minimal:
+  - cockpit-system
+  - cockpit-ws
+
+__cockpit_packages_default:
+  - cockpit
+  - cockpit-bridge
+  - cockpit-machines
+  - cockpit-networkmanager
+  - cockpit-packagekit
+  - cockpit-podman
+  - cockpit-repos
+  - cockpit-selinux
+  - cockpit-storaged
+  - cockpit-subscriptions
+  - cockpit-ws-selinux
+
+__cockpit_packages_full:
+  - cockpit-doc
+  - cockpit-kdump
+  - cockpit-packages
+
+__cockpit_packages:
+  minimal: "{{ __cockpit_packages_minimal }}"
+  default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
+  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default + __cockpit_packages_full }}"

--- a/vars/SLES_SAP-16.yml
+++ b/vars/SLES_SAP-16.yml
@@ -1,0 +1,27 @@
+---
+__cockpit_packages_minimal:
+  - cockpit-system
+  - cockpit-ws
+
+__cockpit_packages_default:
+  - cockpit
+  - cockpit-bridge
+  - cockpit-machines
+  - cockpit-networkmanager
+  - cockpit-packagekit
+  - cockpit-podman
+  - cockpit-repos
+  - cockpit-selinux
+  - cockpit-storaged
+  - cockpit-subscriptions
+  - cockpit-ws-selinux
+
+__cockpit_packages_full:
+  - cockpit-doc
+  - cockpit-kdump
+  - cockpit-packages
+
+__cockpit_packages:
+  minimal: "{{ __cockpit_packages_minimal }}"
+  default: "{{ __cockpit_packages_minimal + __cockpit_packages_default }}"
+  full: "{{ __cockpit_packages_minimal + __cockpit_packages_default + __cockpit_packages_full }}"


### PR DESCRIPTION
Enhancement:  Add SLES 16-specific vars

Reason:  Add support for SLES 16.

Result:  Role works on SLES 16 using new vars/SLES-16.yml.

Issue Tracker Tickets (Jira or BZ if any): na

## Summary by Sourcery

Add support for SUSE SLES 16 by introducing dedicated variable files for package definitions and updating role metadata.

New Features:
- Add vars/SLES-16.yml defining minimal, default, and full cockpit package sets for SLES 16
- Add vars/SLES_SAP-16.yml mirroring package definitions for the SAP variant on SLES 16
- Update meta/main.yml to include SLES 16 as a supported OS and add 'suse' to the galaxy tags