### PR TITLE
test: Use post quantum encryption where available

### DIFF
--- a/tests/tests_certificate_existing.yml
+++ b/tests/tests_certificate_existing.yml
@@ -23,10 +23,22 @@
           args:
             creates: /etc/myserver.key
 
+        - name: Get openssl algorithms
+          command: openssl list -public-key-algorithms
+          register: openssl_algorithms
+          changed_when: false
+          no_log: true  # this is quite verbose
+
+        # Use PQ algorithm if available, otherwise use default
+        # cockpit uses gnutls, which supports mldsa65 since 3.8.10
         - name: Create test certificate cert
-          command: openssl req -new -x509 -key /etc/myserver.key -subj '/CN=localhost' -out /etc/myserver.crt -days 365
+          command: openssl req -x509 {{ key_algo_args }} /etc/myserver.key -subj '/CN=localhost' -out /etc/myserver.crt -days 365
           args:
             creates: /etc/myserver.crt
+          vars:
+            key_algo_args: "{{ '-nodes -newkey mldsa65 -keyout' if 'MLDSA65' in openssl_algorithms.stdout and
+              ansible_facts.packages['gnutls'][0].version is version('3.8.10', '>=')
+              else '-new -key' }}"
 
         # ostree cannot remove packages and cannot cleanup properly
         # this works around that issue


### PR DESCRIPTION
Use `mldsa65` for tests_certificate_existing.yml where available.

Note: openssl in el9 supports `mldsa65` but cockpit service does not.
cockpit uses gnutls - gnutls supports `mlds65` since 3.8.10

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enable post-quantum encryption in certificate creation tests by detecting supported OpenSSL algorithms and falling back to the default method on unsupported systems

Enhancements:
- Support post-quantum certificate generation in tests by selecting the mldsa65 algorithm when available

Tests:
- Add an Ansible task to list available OpenSSL algorithms and dynamically choose between mldsa65 and the default key algorithm