### PR TITLE
feat: Argument spec implementation for cockpit role

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT
+---
+argument_specs:
+  main:
+    short_description: The cockpit role.
+    description: >
+      The cockpit role installs and configures the Cockpit Web Console on
+      distributions that support it, such as RHEL, CentOS, Fedora, Debian,
+      and Ubuntu.
+
+      The role can install predefined or custom package sets, manage the
+      cockpit service state, configure `/etc/cockpit/cockpit.conf`,
+      change the listening port, manage firewall and SELinux settings,
+      and set up TLS certificates.
+    options:
+      cockpit_packages:
+        type: raw
+        default: default
+        description: >
+          The Cockpit packages to install. Accepts a predefined package
+          set (`minimal`, `default`, or `full`) or a list of explicit
+          package names such as `cockpit-storaged` and `cockpit-podman`.
+      cockpit_enabled:
+        type: bool
+        default: true
+        description: >
+          Whether the Cockpit Web Console socket unit is enabled to start
+          automatically at boot.
+      cockpit_started:
+        type: bool
+        default: true
+        description: >
+          Whether the Cockpit Web Console service should be running.
+      cockpit_port:
+        type: raw
+        default: null
+        description: >
+          The TCP port on which Cockpit listens. When set to `null`, the
+          default port `9090` is used.
+      cockpit_manage_firewall:
+        type: bool
+        default: false
+        description: >
+          Whether to configure the firewall for Cockpit using the firewall
+          role. Supported on Red Hat family and SUSE distributions.
+      cockpit_manage_selinux:
+        type: bool
+        default: false
+        description: >
+          Whether to configure SELinux port policy for Cockpit using the
+          selinux role when a custom port is used.
+      cockpit_certificates:
+        type: list
+        elements: dict
+        default: []
+        description: >
+          A list of certificate request specifications passed to the
+          certificate role. Each item describes a certificate to be
+          issued for Cockpit.
+        options:
+          name:
+            type: str
+            required: true
+            description: >
+              The name of the certificate. A full path can be used to
+              choose the directory where files will be stored.
+          ca:
+            type: str
+            required: true
+            description: >
+              The CA that will issue the certificate (for example
+              `self-sign` or `ipa`).
+          dns:
+            type: raw
+            description: >
+              A domain name or list of domain names to include in the
+              certificate Subject Alternative Name (SAN).
+          email:
+            type: raw
+            description: >
+              An email address or list of email addresses to include in
+              the certificate Subject Alternative Name (SAN).
+          ip:
+            type: raw
+            description: >
+              An IP address or list of IP addresses to include in the
+              certificate Subject Alternative Name (SAN).
+          auto_renew:
+            type: bool
+            default: true
+            description: >
+              Whether the certificate should be renewed automatically
+              before it expires.
+          owner:
+            type: str
+            description: >
+              The user name or user id for the certificate and key files.
+          group:
+            type: str
+            description: >
+              The group name or group id for the certificate and key
+              files.
+          mode:
+            type: raw
+            description: >
+              The file system permissions for the certificate and key
+              files. Accepts a string (for example `0644`) or an integer.
+          key_size:
+            type: int
+            description: >
+              The key size in bits.
+          common_name:
+            type: str
+            description: >
+              The Common Name requested for the certificate subject.
+          country:
+            type: str
+            description: >
+              The country code requested for the certificate subject.
+          state:
+            type: str
+            description: >
+              The state requested for the certificate subject.
+          locality:
+            type: str
+            description: >
+              The locality requested for the certificate subject.
+          organization:
+            type: str
+            description: >
+              The organization requested for the certificate subject.
+          organizational_unit:
+            type: str
+            description: >
+              The organizational unit requested for the certificate
+              subject.
+          contact_email:
+            type: str
+            description: >
+              The contact email requested for the certificate subject.
+          key_usage:
+            type: list
+            elements: str
+            choices:
+              - digitalSignature
+              - nonRepudiation
+              - keyEncipherment
+              - dataEncipherment
+              - keyAgreement
+              - keyCertSign
+              - cRLSign
+              - encipherOnly
+              - decipherOnly
+            default:
+              - digitalSignature
+              - keyEncipherment
+            description: >
+              The allowed Key Usage extensions for the certificate.
+          extended_key_usage:
+            type: list
+            elements: str
+            default:
+              - id-kp-serverAuth
+              - id-kp-clientAuth
+            description: >
+              The Extended Key Usage attributes for the certificate.
+          run_before:
+            type: str
+            description: >
+              A command to run before saving the certificate.
+          run_after:
+            type: str
+            description: >
+              A command to run after saving the certificate.
+          principal:
+            type: raw
+            description: >
+              A Kerberos principal or list of Kerberos principals.
+          provider:
+            type: str
+            default: certmonger
+            description: >
+              The underlying method used to request and manage the
+              certificate.
+          issuer:
+            type: str
+            description: >
+              The issuer certificate nickname or template name.
+      cockpit_transactional_update_reboot_ok:
+        type: raw
+        default: null
+        description: >
+          Whether the role may reboot the system when a transactional
+          update requires it. When set to `null`, the role fails if a
+          reboot is required.

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Assert cockpit_packages is a predefined type or list of package names
+  ansible.builtin.assert:
+    that:
+      - >-
+        (cockpit_packages is string
+         and cockpit_packages in ['minimal', 'default', 'full'])
+        or (cockpit_packages is sequence and cockpit_packages is not mapping
+            and cockpit_packages is not string
+            and cockpit_packages | reject('string') | list | length == 0)
+    fail_msg: >-
+      cockpit_packages must be minimal, default, full, or a list of package
+      names, got {{ cockpit_packages | type_debug }}
+  when: cockpit_packages is defined
+
+- name: Assert cockpit_port is null or an integer
+  ansible.builtin.assert:
+    that:
+      - >-
+        (cockpit_port is none)
+        or ((cockpit_port | type_debug) == 'int')
+    fail_msg: >-
+      cockpit_port must be null or an integer,
+      got {{ cockpit_port | type_debug }}
+  when: cockpit_port is defined
+
+- name: Assert cockpit_transactional_update_reboot_ok is null or a boolean
+  ansible.builtin.assert:
+    that:
+      - >-
+        (cockpit_transactional_update_reboot_ok is none)
+        or (cockpit_transactional_update_reboot_ok is sameas true)
+        or (cockpit_transactional_update_reboot_ok is sameas false)
+    fail_msg: >-
+      cockpit_transactional_update_reboot_ok must be null or a boolean,
+      got {{ cockpit_transactional_update_reboot_ok | type_debug }}
+
+- name: Assert dns in cockpit_certificates is a string or list of strings
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.dns is string
+        or (item.dns is sequence and item.dns is not mapping
+            and item.dns is not string
+            and item.dns | reject('string') | list | length == 0)
+    fail_msg: >-
+      cockpit_certificates[{{ idx }}].dns must be a string or list of
+      strings, got {{ item.dns | type_debug }}
+  loop: "{{ cockpit_certificates }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.name | d('unnamed') }}"
+  when:
+    - cockpit_certificates | length > 0
+    - item.dns is defined
+
+- name: Assert email in cockpit_certificates is a string or list of strings
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.email is string
+        or (item.email is sequence and item.email is not mapping
+            and item.email is not string
+            and item.email | reject('string') | list | length == 0)
+    fail_msg: >-
+      cockpit_certificates[{{ idx }}].email must be a string or list of
+      strings, got {{ item.email | type_debug }}
+  loop: "{{ cockpit_certificates }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.name | d('unnamed') }}"
+  when:
+    - cockpit_certificates | length > 0
+    - item.email is defined
+
+- name: Assert ip in cockpit_certificates is a string or list of strings
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.ip is string
+        or (item.ip is sequence and item.ip is not mapping
+            and item.ip is not string
+            and item.ip | reject('string') | list | length == 0)
+    fail_msg: >-
+      cockpit_certificates[{{ idx }}].ip must be a string or list of
+      strings, got {{ item.ip | type_debug }}
+  loop: "{{ cockpit_certificates }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.name | d('unnamed') }}"
+  when:
+    - cockpit_certificates | length > 0
+    - item.ip is defined
+
+- name: Assert principal in cockpit_certificates is a string or list of strings
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.principal is string
+        or (item.principal is sequence and item.principal is not mapping
+            and item.principal is not string
+            and item.principal | reject('string') | list | length == 0)
+    fail_msg: >-
+      cockpit_certificates[{{ idx }}].principal must be a string or list of
+      strings, got {{ item.principal | type_debug }}
+  loop: "{{ cockpit_certificates }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.name | d('unnamed') }}"
+  when:
+    - cockpit_certificates | length > 0
+    - item.principal is defined
+
+- name: Assert mode in cockpit_certificates is a string or integer
+  ansible.builtin.assert:
+    that:
+      - (item.mode | type_debug) in ['str', 'int', 'unicode']
+    fail_msg: >-
+      cockpit_certificates[{{ idx }}].mode must be a string or integer,
+      got {{ item.mode | type_debug }}
+  loop: "{{ cockpit_certificates }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.name | d('unnamed') }}"
+  when:
+    - cockpit_certificates | length > 0
+    - item.mode is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Ensure ansible_facts and variables used by role
   include_tasks: tasks/set_vars.yml
 
+- name: Validate role parameters
+  ansible.builtin.include_tasks: assert_role_vars.yml
+
 - name: Enable the Extras repository on RHEL 7
   when:
     - ansible_facts["distribution"] == 'RedHat'

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify invalid parameters are rejected
+  hosts: all
+  tasks:
+    - name: Run invalid input tests
+      block:
+        # ====================================================
+        # Section 1: Verify role works with valid defaults
+        # ====================================================
+        - name: Run role with valid defaults
+          ansible.builtin.include_role:
+            name: linux-system-roles.cockpit
+
+        # ====================================================
+        # Section 2: argument_specs validation (Ansible 2.11+)
+        # ====================================================
+        - name: Run argument specs validation tests
+          when: ansible_version.full is version("2.11", ">=")
+          block:
+            # --- Test: required field missing ---
+            - name: Argument specs reject missing required name
+              block:
+                - name: Run role without required name in cockpit_certificates
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.cockpit
+                  vars:
+                    cockpit_certificates:
+                      - ca: self-sign
+              rescue:
+                - name: Mark missing name rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_missing_name_failed: true
+                  when: >-
+                    'missing required arguments' in
+                    (ansible_failed_result | default({}) | to_json)
+
+            - name: Assert missing name was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_missing_name_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject cockpit_certificates entries
+                  missing the required name field
+
+            - name: Argument specs reject missing required ca
+              block:
+                - name: Run role without required ca in cockpit_certificates
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.cockpit
+                  vars:
+                    cockpit_certificates:
+                      - name: test-cert
+              rescue:
+                - name: Mark missing ca rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_missing_ca_failed: true
+                  when: >-
+                    'missing required arguments' in
+                    (ansible_failed_result | default({}) | to_json)
+
+            - name: Assert missing ca was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_missing_ca_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject cockpit_certificates entries
+                  missing the required ca field
+
+            # --- Test: invalid type ---
+            - name: Argument specs reject non-bool cockpit_enabled
+              block:
+                - name: Run role with non-bool cockpit_enabled
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.cockpit
+                  vars:
+                    cockpit_enabled: "not_a_bool"
+              rescue:
+                - name: Mark invalid cockpit_enabled type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_cockpit_enabled_type_failed: true
+
+            - name: Assert invalid cockpit_enabled type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_cockpit_enabled_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject cockpit_enabled with type
+                  string
+
+            - name: Argument specs reject non-bool cockpit_manage_firewall
+              block:
+                - name: Run role with non-bool cockpit_manage_firewall
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.cockpit
+                  vars:
+                    cockpit_manage_firewall: "not_a_bool"
+              rescue:
+                - name: Mark invalid cockpit_manage_firewall type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_cockpit_manage_firewall_type_failed: true
+
+            - name: Assert invalid cockpit_manage_firewall type was rejected
+              ansible.builtin.assert:
+                that:
+                  - >-
+                    __invalid_input_cockpit_manage_firewall_type_failed
+                    | default(false)
+                fail_msg: >-
+                  argument_specs should reject cockpit_manage_firewall with
+                  type string
+
+            - name: Argument specs reject invalid key_usage choice
+              block:
+                - name: Run role with invalid key_usage choice
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.cockpit
+                  vars:
+                    cockpit_certificates:
+                      - name: test-cert
+                        ca: self-sign
+                        key_usage:
+                          - invalid_choice
+              rescue:
+                - name: Mark invalid key_usage choice rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_key_usage_choice_failed: true
+
+            - name: Assert invalid key_usage choice was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_key_usage_choice_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject key_usage value
+                  'invalid_choice'
+
+        # ====================================================
+        # Section 3: assert_role_vars validation (all versions)
+        # ====================================================
+
+        - name: Assert rejects cockpit_packages as integer
+          block:
+            - name: Run role with cockpit_packages as integer
+              ansible.builtin.include_role:
+                name: linux-system-roles.cockpit
+              vars:
+                cockpit_packages: 123
+          rescue:
+            - name: Mark cockpit_packages integer rejected
+              ansible.builtin.set_fact:
+                __invalid_input_cockpit_packages_integer_failed: true
+
+        - name: Assert cockpit_packages integer was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_cockpit_packages_integer_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject cockpit_packages when given
+              an integer value
+
+        - name: Assert rejects cockpit_port as string
+          block:
+            - name: Run role with cockpit_port as string
+              ansible.builtin.include_role:
+                name: linux-system-roles.cockpit
+              vars:
+                cockpit_port: "not_an_int"
+          rescue:
+            - name: Mark cockpit_port string rejected
+              ansible.builtin.set_fact:
+                __invalid_input_cockpit_port_string_failed: true
+
+        - name: Assert cockpit_port string was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_cockpit_port_string_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject cockpit_port when given
+              a string value
+
+        - name: Assert rejects cockpit_transactional_update_reboot_ok as string
+          block:
+            - name: Run role with cockpit_transactional_update_reboot_ok as string
+              ansible.builtin.include_role:
+                name: linux-system-roles.cockpit
+              vars:
+                cockpit_transactional_update_reboot_ok: "not_a_bool"
+          rescue:
+            - name: Mark cockpit_transactional_update_reboot_ok string rejected
+              ansible.builtin.set_fact:
+                __invalid_input_cockpit_transactional_update_reboot_ok_string_failed: true
+
+        - name: Assert cockpit_transactional_update_reboot_ok string was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_cockpit_transactional_update_reboot_ok_string_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject cockpit_transactional_update_reboot_ok
+              when given a string value
+
+        - name: Assert rejects cockpit_certificates dns as integer
+          block:
+            - name: Run role with cockpit_certificates dns as integer
+              ansible.builtin.include_role:
+                name: linux-system-roles.cockpit
+              vars:
+                cockpit_certificates:
+                  - name: test-cert
+                    ca: self-sign
+                    dns: 123
+          rescue:
+            - name: Mark cockpit_certificates dns integer rejected
+              ansible.builtin.set_fact:
+                __invalid_input_cockpit_certificates_dns_integer_failed: true
+
+        - name: Assert cockpit_certificates dns integer was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_cockpit_certificates_dns_integer_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject cockpit_certificates dns when
+              given an integer value
+
+      always:
+        - name: Clear test facts
+          ansible.builtin.set_fact:
+            __invalid_input_missing_name_failed:
+            __invalid_input_missing_ca_failed:
+            __invalid_input_cockpit_enabled_type_failed:
+            __invalid_input_cockpit_manage_firewall_type_failed:
+            __invalid_input_key_usage_choice_failed:
+            __invalid_input_cockpit_packages_integer_failed:
+            __invalid_input_cockpit_port_string_failed:
+            __invalid_input_cockpit_transactional_update_reboot_ok_string_failed:
+            __invalid_input_cockpit_certificates_dns_integer_failed:
+          tags: tests::cleanup


### PR DESCRIPTION
Enhancement: Added argument spec and assert role spec validation to the cockpit role. Also wrote tests for it found in tests/tests_invalid_input.

Reason: Because it is a good addition to the linux-system-roles project.

Result: Successfully added it and prepared tests for it. I used AI during this implementation.

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/postfix/issues/206 https://redhat.atlassian.net/browse/RHELMISC-16008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documented configuration options for Cockpit packages, service startup, port selection, firewall and SELinux management, certificates, and transactional update reboots.
  * Added support for validating certificate configuration fields and their accepted values.

* **Bug Fixes**
  * Invalid role settings are now detected before Cockpit setup begins, with clearer error messages identifying the problematic values.

* **Tests**
  * Added coverage for valid defaults and invalid package, port, certificate, boolean, DNS, and reboot-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->